### PR TITLE
Add content-addressed render cache

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -46,6 +46,13 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      - name: Restore generated audio cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ inputs.output_dir }}
+          key: audio-engine-v1-${{ runner.os }}-${{ github.repository }}-${{ inputs.engine_ref }}-${{ github.sha }}
+          restore-keys: |
+            audio-engine-v1-${{ runner.os }}-${{ github.repository }}-${{ inputs.engine_ref }}-
       - name: Install audio-engine
         run: python -m pip install --disable-pip-version-check ./.audio-engine
       - name: Render batch, best effort

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Segments may use an explicit provider voice, a validated `preset`, or a `target`
 
 The engine normalizes the final assembled asset. Segment files are temporary and are never part of the published output.
 
+## Content-addressed reuse
+
+A completed render is reusable only when its render fingerprint still matches. The fingerprint includes:
+
+- source JSON SHA-256;
+- voice configuration SHA-256;
+- rendering-code SHA-256;
+- provider name;
+- output profile.
+
+If those inputs are unchanged and `audio.mp3` plus `transcript.json` are present, `render` returns a cache hit without calling the TTS provider. The reusable GitHub workflow also restores the previous generated-audio directory with `actions/cache`, so a consumer changing one episode normally regenerates only that episode.
+
+`render-report.json` distinguishes `rendered_count`, `cached_count`, and failures.
+
 ## Provider and privacy
 
 The current provider is Edge TTS. Processing is **remote**: text sent for synthesis leaves the runner. Do not use the remote provider for content that must not be sent to an external TTS service.

--- a/src/audio_engine/batch.py
+++ b/src/audio_engine/batch.py
@@ -4,22 +4,34 @@ from pathlib import Path
 
 from .render import render_program
 
+
 def render_batch(pattern, output_root, voices_path=None):
     output_root = Path(output_root)
     output_root.mkdir(parents=True, exist_ok=True)
     sources = sorted(path for path in glob.glob(pattern, recursive=True) if Path(path).is_file())
-    rendered = []
+    completed = []
     failures = []
+    rendered_count = 0
+    cached_count = 0
     for source in sources:
         try:
             manifest = render_program(source, output_root, voices_path)
-            rendered.append({"source": source, "id": manifest["id"]})
+            cache_hit = bool(manifest.get("cache_hit"))
+            if cache_hit:
+                cached_count += 1
+            else:
+                rendered_count += 1
+            completed.append({
+                "source": source,
+                "id": manifest["id"],
+                "cache_hit": cache_hit,
+            })
         except Exception as exc:
             failures.append({"source": source, "error": str(exc)})
     status = "success"
     if not sources:
         status = "empty"
-    elif failures and rendered:
+    elif failures and completed:
         status = "partial"
     elif failures:
         status = "failed"
@@ -27,9 +39,11 @@ def render_batch(pattern, output_root, voices_path=None):
         "schema_version": 1,
         "status": status,
         "source_count": len(sources),
-        "rendered_count": len(rendered),
+        "success_count": len(completed),
+        "rendered_count": rendered_count,
+        "cached_count": cached_count,
         "failure_count": len(failures),
-        "rendered": rendered,
+        "completed": completed,
         "failures": failures,
     }
     (output_root / "render-report.json").write_text(

--- a/src/audio_engine/render.py
+++ b/src/audio_engine/render.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import tempfile
 from pathlib import Path
@@ -9,17 +10,82 @@ from .profiles import get_profile
 from .providers.edge import EdgeProvider
 from .voices import load_voice_config, resolve_segments
 
+
+def engine_code_sha256():
+    root = Path(__file__).parent
+    files = [
+        root / "render.py",
+        root / "audio.py",
+        root / "profiles.py",
+        root / "voices.py",
+        root / "providers" / "edge.py",
+    ]
+    digest = hashlib.sha256()
+    for path in files:
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def render_fingerprint(source_sha, voice_config_sha, engine_code_sha, provider_name, profile_name):
+    payload = {
+        "source_sha256": source_sha,
+        "voice_config_sha256": voice_config_sha,
+        "engine_code_sha256": engine_code_sha,
+        "provider": provider_name,
+        "profile": profile_name,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def cached_manifest(output_dir, expected_fingerprint):
+    manifest_path = output_dir / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if manifest.get("render_fingerprint") != expected_fingerprint:
+        return None
+    audio_file = manifest.get("audio", {}).get("file")
+    transcript_file = manifest.get("transcript")
+    if not audio_file or not (output_dir / audio_file).exists():
+        return None
+    if not transcript_file or not (output_dir / transcript_file).exists():
+        return None
+    if manifest.get("status") != "success":
+        return None
+    return manifest
+
+
 def render_program(program_path, output_root, voices_path=None, provider=None):
     program_path = Path(program_path)
     program = validate_program(load_json(program_path))
     profile_name = program.get("profile", "speech")
     profile = get_profile(profile_name)
     voice_config, voice_config_path = load_voice_config(voices_path)
-    resolved = resolve_segments(program, voice_config)
     provider = provider or EdgeProvider()
+
+    source_sha = sha256_file(program_path)
+    voice_config_sha = sha256_file(voice_config_path)
+    engine_sha = engine_code_sha256()
+    fingerprint = render_fingerprint(
+        source_sha,
+        voice_config_sha,
+        engine_sha,
+        provider.name,
+        profile_name,
+    )
 
     output_dir = Path(output_root) / program["id"]
     output_dir.mkdir(parents=True, exist_ok=True)
+    cached = cached_manifest(output_dir, fingerprint)
+    if cached:
+        return {**cached, "cache_hit": True}
+
+    resolved = resolve_segments(program, voice_config)
     audio_path = output_dir / "audio.mp3"
 
     with tempfile.TemporaryDirectory() as temp_value:
@@ -60,8 +126,10 @@ def render_program(program_path, output_root, voices_path=None, provider=None):
         "schema_version": 1,
         "id": program["id"],
         "status": "success",
-        "source_sha256": sha256_file(program_path),
-        "voice_config_sha256": sha256_file(voice_config_path),
+        "source_sha256": source_sha,
+        "voice_config_sha256": voice_config_sha,
+        "engine_code_sha256": engine_sha,
+        "render_fingerprint": fingerprint,
         "engine_version": __version__,
         "provider": {
             "name": provider.name,
@@ -84,4 +152,4 @@ def render_program(program_path, output_root, voices_path=None, provider=None):
         json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
     )
-    return manifest
+    return {**manifest, "cache_hit": False}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -14,7 +14,11 @@ class FakeProvider:
     name = "fake"
     processing = "local-test"
 
+    def __init__(self):
+        self.calls = 0
+
     def synthesize(self, segment, path):
+        self.calls += 1
         run_ffmpeg([
             "-f", "lavfi",
             "-i", "anullsrc=r=24000:cl=mono",
@@ -61,7 +65,7 @@ class SmokeTests(unittest.TestCase):
             result["recommendations"][1]["score"],
         )
 
-    def test_render_offline_provider(self):
+    def test_render_offline_provider_and_cache(self):
         with tempfile.TemporaryDirectory() as temp_value:
             root = Path(temp_value)
             program = root / "program.json"
@@ -79,14 +83,41 @@ class SmokeTests(unittest.TestCase):
                 ],
             }), encoding="utf-8")
             out = root / "out"
-            manifest = render_program(program, out, provider=FakeProvider())
+            provider = FakeProvider()
+            manifest = render_program(program, out, provider=provider)
             self.assertEqual(manifest["status"], "success")
+            self.assertFalse(manifest["cache_hit"])
+            self.assertEqual(provider.calls, 1)
             self.assertEqual(manifest["audio"]["bitrate_kbps"], 80)
             self.assertEqual(manifest["audio"]["sample_rate_hz"], 24000)
             self.assertEqual(manifest["audio"]["channels"], 1)
+            self.assertTrue(manifest["render_fingerprint"])
             self.assertTrue((out / "smoke" / "audio.mp3").stat().st_size > 0)
             self.assertTrue((out / "smoke" / "manifest.json").exists())
             self.assertTrue((out / "smoke" / "transcript.json").exists())
+
+            cached = render_program(program, out, provider=provider)
+            self.assertTrue(cached["cache_hit"])
+            self.assertEqual(provider.calls, 1)
+            self.assertEqual(cached["render_fingerprint"], manifest["render_fingerprint"])
+
+            program.write_text(json.dumps({
+                "schema_version": 1,
+                "id": "smoke",
+                "title": "Smoke",
+                "profile": "speech",
+                "segments": [
+                    {
+                        "voice": "unused-test-voice",
+                        "text": "Changed",
+                        "pause_after_ms": 100,
+                    }
+                ],
+            }), encoding="utf-8")
+            changed = render_program(program, out, provider=provider)
+            self.assertFalse(changed["cache_hit"])
+            self.assertEqual(provider.calls, 2)
+            self.assertNotEqual(changed["render_fingerprint"], manifest["render_fingerprint"])
 
     def test_assemble(self):
         with tempfile.TemporaryDirectory() as temp_value:


### PR DESCRIPTION
Performance safeguard before full catalog migration.

- reuse a completed render only when source, voice config, rendering code, provider and output profile fingerprint all match;
- expose `cache_hit` to CLI callers;
- batch report separates rendered vs cached assets;
- reusable workflow restores generated audio via Actions cache;
- offline smoke test proves unchanged input skips provider synthesis and changed input invalidates the cache.

No change to schema v1 or output audio quality.