### PR TITLE
Reuse safe stage caches across engine refs

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -46,13 +46,14 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - name: Restore generated audio cache
+      - name: Restore generated audio and stage caches
         uses: actions/cache@v4
         with:
           path: ${{ inputs.output_dir }}
-          key: audio-engine-v1-${{ runner.os }}-${{ github.repository }}-${{ inputs.engine_ref }}-${{ github.sha }}
+          key: audio-engine-v2-${{ runner.os }}-${{ github.repository }}-${{ github.sha }}
           restore-keys: |
-            audio-engine-v1-${{ runner.os }}-${{ github.repository }}-${{ inputs.engine_ref }}-
+            audio-engine-v2-${{ runner.os }}-${{ github.repository }}-
+            audio-engine-v1-${{ runner.os }}-${{ github.repository }}-
       - name: Install audio-engine
         run: python -m pip install --disable-pip-version-check ./.audio-engine
       - name: Render batch, best effort


### PR DESCRIPTION
Keep the reusable workflow cache aligned with Audio Engine 0.2 stage-level fingerprints.

- stop partitioning the restored output/cache directory by `engine_ref`;
- use a v2 cache namespace keyed by caller repository + commit;
- restore prior v2 caches across engine refs;
- allow one-way fallback to existing v1 cache archives during migration;
- correctness remains enforced by the engine's master, voice and ambience fingerprints, so stale outputs are not silently accepted.

This reduces unnecessary network synthesis when a consumer advances its pinned Audio Engine SHA.