### PR TITLE
Broaden ambience sourcing beyond Wikimedia

### DIFF
--- a/docs/AMBIENCES.md
+++ b/docs/AMBIENCES.md
@@ -25,15 +25,43 @@ The catalog may legitimately contain zero entries. An ambience is added only aft
 6. loopability recorded when relevant;
 7. durable production snapshot strategy established.
 
-A small empty catalog is preferable to an impressive but unreliable sound library.
+A small curated catalog is preferable to an impressive but unreliable sound library. Discovery, however, must be broad.
+
+## Broad discovery, narrow promotion
+
+The sourcing rule is:
+
+> Search widely. Qualify strictly. Produce from a locked asset.
+
+Discovery should not be limited to one or two websites. Useful source families include:
+
+### Open / broadly redistributable discovery
+
+- Openverse — cross-provider discovery of openly licensed audio; verify the upstream licence before promotion;
+- Wikimedia Commons — strong provenance and open licences, but uneven ambience coverage;
+- Freesound — very broad field-recording community with CC0 / CC BY / CC BY-NC assets; filter licence deliberately;
+- Internet Archive and other open archives may be searched when a specific recording is relevant, with per-item licence verification.
+
+### Free / royalty-free production libraries
+
+- Pixabay — large royalty-free sound-effects catalogue; raw standalone redistribution restrictions must be respected;
+- Mixkit — free commercial-use sound effects, useful for common ambience categories;
+- ZapSplat — large catalogue, including some CC0 material plus provider-specific licensed sounds;
+- Sonniss #GameAudioGDC — professional royalty-free giveaway archives; raw standalone redistribution is not allowed.
+
+### Professional field-recording and SFX libraries
+
+- Free To Use Sounds — high-resolution real-world and immersive field recordings;
+- Soundly — large searchable cloud library and add-on ecosystem;
+- BOOM Library — studio-grade professional SFX and ambience libraries;
+- Pro Sound Effects — professional commercial SFX catalogue;
+- Pond5 and similar stock-audio marketplaces — useful fallback when a precise ambience cannot be sourced elsewhere.
+
+This list is a discovery surface, not an allow-list. A provider name never substitutes for checking the licence of the exact asset.
 
 ## Web discovery versus production
 
-The policy is:
-
-> Discover on the Web. Qualify once. Produce from a locked asset.
-
-Web services such as Wikimedia Commons or Openverse can help find candidates, but Web search/download is intentionally outside the `render` contract.
+Web search/download is intentionally outside the `render` contract.
 
 A production program uses a local relative `ambience.file`. The file may be:
 
@@ -43,6 +71,15 @@ A production program uses a local relative `ambience.file`. The file may be:
 
 Playback never depends on the third-party source: the ambience is mixed into the final master.
 
+## Snapshot and redistribution rule
+
+Two asset classes must be treated differently:
+
+1. **Redistributable source assets** — for example CC0 or suitable CC BY material. The original may be snapshotted in a durable shared location when the licence permits it and attribution obligations are preserved.
+2. **Production-only licensed assets** — many royalty-free commercial libraries permit use inside a finished production but forbid redistribution of the raw sound. These originals must not be committed to a public repository or public Release as standalone files. Keep the licensed source in an appropriate private/local asset location and publish only the resulting mixed production plus provenance metadata permitted by the licence.
+
+The engine does not need to know which storage product is used. It only receives the qualified local file at render time.
+
 ## Licence policy
 
 Initial automated policy is deliberately conservative:
@@ -50,6 +87,7 @@ Initial automated policy is deliberately conservative:
 - CC0 / public-domain equivalent: suitable after provenance and quality checks;
 - CC BY: suitable after attribution requirements are captured;
 - CC BY-SA: manual review;
+- provider-specific royalty-free licences: manual review of the exact asset and raw-redistribution rules;
 - NC or ND restrictions: rejected by default for the shared generic catalog.
 
 The catalog policy is machine-readable in `ambiences.json`; it is guidance, not legal advice.
@@ -64,8 +102,8 @@ A future qualified entry should look broadly like:
   "label": "Cathedral — calm room tone",
   "tags": ["interior", "calm", "stereo", "loopable"],
   "source": {
-    "provider": "Wikimedia Commons",
-    "identifier": "File:Example.flac",
+    "provider": "qualified provider",
+    "identifier": "provider asset id",
     "page": "canonical source page"
   },
   "license": {

--- a/src/audio_engine/ambiences.json
+++ b/src/audio_engine/ambiences.json
@@ -4,9 +4,24 @@
   "policy": {
     "web_discovery": "outside-render",
     "production": "locked-snapshot",
-    "preferred_sources": ["Wikimedia Commons"],
+    "preferred_sources": [
+      "Openverse",
+      "Wikimedia Commons",
+      "Pixabay",
+      "Freesound",
+      "ZapSplat",
+      "Mixkit",
+      "Sonniss GameAudioGDC",
+      "Free To Use Sounds",
+      "Soundly",
+      "BOOM Library",
+      "Pro Sound Effects",
+      "Pond5"
+    ],
+    "source_license_verification": "per-asset",
+    "raw_redistribution": "license-dependent",
     "automatic_licenses": ["CC0-1.0", "CC-BY-4.0"],
-    "manual_review_licenses": ["CC-BY-SA-4.0"],
+    "manual_review_licenses": ["CC-BY-SA-4.0", "provider-specific"],
     "rejected_by_default": ["CC-BY-NC-*", "CC-BY-ND-*"]
   },
   "entries": []


### PR DESCRIPTION
Broaden ambience discovery without changing the render boundary.

- expand the machine-readable source policy from one preferred source to a 12-source discovery surface;
- document open, free/royalty-free, and professional source families;
- keep Web discovery outside render;
- distinguish redistributable assets from production-only licensed assets so raw commercial SFX never leak into a public repo;
- keep exact per-asset licence/provenance/listening/hash qualification as the promotion gate.

No mixer, CLI contract or rendering behavior changes.