### PR TITLE
Reduce transient artifact retention

### DIFF
--- a/.github/workflows/hydrate-sounds.yml
+++ b/.github/workflows/hydrate-sounds.yml
@@ -72,6 +72,7 @@ jobs:
           name: ${{ inputs.artifact_name }}
           path: sound-library
           if-no-files-found: error
+          retention-days: 1
       - name: Enforce unresolved policy
         if: inputs.fail_on_unresolved
         run: |

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -104,3 +104,4 @@ jobs:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.output_dir }}
           if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
P2 storage hygiene: keep rendered audio and hydrated sound-library workflow artifacts for one day only. Durable validated sounds remain in the caller Release; caches remain independently managed.