### PR TITLE
Normalize provider edge silence in voice clips

### DIFF
--- a/src/audio_engine/voice/render.py
+++ b/src/audio_engine/voice/render.py
@@ -1,12 +1,19 @@
 import hashlib
 import inspect
 import json
-import shutil
 from pathlib import Path
 
-from ..audio import probe_duration_seconds
+from ..audio import probe_duration_seconds, run_ffmpeg
 
-_SYNTHESIS_CONTRACT = "voice-synthesis-v1"
+_SYNTHESIS_CONTRACT = "voice-synthesis-v2-edge-silence-normalized"
+_EDGE_FILTER = (
+    "silenceremove="
+    "start_periods=1:start_duration=0.02:start_threshold=-45dB:start_silence=0.06,"
+    "areverse,"
+    "silenceremove="
+    "start_periods=1:start_duration=0.02:start_threshold=-45dB:start_silence=0.10,"
+    "areverse"
+)
 
 
 def _provider_code_sha256(provider):
@@ -56,13 +63,40 @@ def _metadata_path(path):
     return Path(path).with_suffix(".json")
 
 
+def _normalize_voice_edges(source, destination):
+    """Remove provider padding at clip edges while preserving internal pauses.
+
+    Edge TTS commonly emits around a second of terminal digital silence. That
+    padding is transport noise, not authored cadence: `pause_after_ms` remains
+    the only explicit inter-segment pause. Reverse + start-only trimming keeps
+    internal hesitations untouched and retains a small safety cushion at both
+    clip boundaries.
+    """
+    source = Path(source)
+    destination = Path(destination)
+    destination.unlink(missing_ok=True)
+    run_ffmpeg([
+        "-i", str(source),
+        "-af", _EDGE_FILTER,
+        "-map_metadata", "-1",
+        "-ac", "1",
+        "-c:a", "libmp3lame",
+        "-b:a", "96k",
+        str(destination),
+    ])
+    duration = probe_duration_seconds(destination)
+    if duration is None or duration <= 0.05:
+        destination.unlink(missing_ok=True)
+        raise RuntimeError("Voice edge normalization produced no usable audio")
+
+
 def _timing_metadata(segment, provider, fingerprint, path):
     duration = probe_duration_seconds(path)
     if duration is None:
         raise RuntimeError("Could not determine rendered voice duration")
     text = segment.get("text", "")
     return {
-        "version": 1,
+        "version": 2,
         "fingerprint": fingerprint,
         "provider": provider.name,
         "voice": segment["voice"],
@@ -71,6 +105,7 @@ def _timing_metadata(segment, provider, fingerprint, path):
         "volume": segment.get("volume", "+0%"),
         "text_chars": len(text),
         "text_words": len(text.split()),
+        "edge_silence_normalized": True,
         "measured_duration_ms": round(duration * 1000.0, 3),
     }
 
@@ -80,7 +115,11 @@ def _ensure_timing_metadata(segment, provider, fingerprint, path):
     if metadata_path.exists():
         try:
             data = json.loads(metadata_path.read_text(encoding="utf-8"))
-            if data.get("fingerprint") == fingerprint and data.get("measured_duration_ms"):
+            if (
+                data.get("fingerprint") == fingerprint
+                and data.get("measured_duration_ms")
+                and data.get("edge_silence_normalized") is True
+            ):
                 return data
         except Exception:
             pass
@@ -112,15 +151,22 @@ def render_voice_clip(segment, provider, cache_root, fallback_fingerprints=None)
             continue
         legacy = cache_root / f"{fallback}.mp3"
         if legacy.exists() and legacy.stat().st_size > 0:
-            shutil.copyfile(legacy, path)
+            _normalize_voice_edges(legacy, path)
             _ensure_timing_metadata(segment, provider, fingerprint, path)
             return path, True, fingerprint
 
-    temporary = path.with_suffix(".tmp.mp3")
-    temporary.unlink(missing_ok=True)
-    provider.synthesize(segment, temporary)
-    if not temporary.exists() or temporary.stat().st_size <= 0:
-        raise RuntimeError("Voice provider produced no audio")
-    temporary.replace(path)
+    raw = path.with_suffix(".raw.tmp.mp3")
+    normalized = path.with_suffix(".normalized.tmp.mp3")
+    raw.unlink(missing_ok=True)
+    normalized.unlink(missing_ok=True)
+    try:
+        provider.synthesize(segment, raw)
+        if not raw.exists() or raw.stat().st_size <= 0:
+            raise RuntimeError("Voice provider produced no audio")
+        _normalize_voice_edges(raw, normalized)
+        normalized.replace(path)
+    finally:
+        raw.unlink(missing_ok=True)
+        normalized.unlink(missing_ok=True)
     _ensure_timing_metadata(segment, provider, fingerprint, path)
     return path, False, fingerprint

--- a/tests/test_voice_cache_migration.py
+++ b/tests/test_voice_cache_migration.py
@@ -7,6 +7,35 @@ from audio_engine.audio import run_ffmpeg
 from audio_engine.render import render_program
 
 
+def write_tone(path, duration=0.7):
+    run_ffmpeg([
+        "-f", "lavfi",
+        "-i", f"sine=frequency=440:sample_rate=24000:duration={duration}",
+        "-ac", "1",
+        "-c:a", "libmp3lame",
+        "-b:a", "64k",
+        str(path),
+    ])
+
+
+def write_padded_tone(path):
+    # 200 ms provider lead + 300 ms speech + 250 ms intentional internal pause
+    # + 300 ms speech + 1000 ms provider tail = 2050 ms raw.
+    run_ffmpeg([
+        "-f", "lavfi", "-i", "anullsrc=r=24000:cl=mono:d=0.2",
+        "-f", "lavfi", "-i", "sine=frequency=440:sample_rate=24000:duration=0.3",
+        "-f", "lavfi", "-i", "anullsrc=r=24000:cl=mono:d=0.25",
+        "-f", "lavfi", "-i", "sine=frequency=440:sample_rate=24000:duration=0.3",
+        "-f", "lavfi", "-i", "anullsrc=r=24000:cl=mono:d=1.0",
+        "-filter_complex", "[0:a][1:a][2:a][3:a][4:a]concat=n=5:v=0:a=1[out]",
+        "-map", "[out]",
+        "-ac", "1",
+        "-c:a", "libmp3lame",
+        "-b:a", "64k",
+        str(path),
+    ])
+
+
 class FakeProvider:
     name = "fake-migrate"
     processing = "local-test"
@@ -16,18 +45,19 @@ class FakeProvider:
 
     def synthesize(self, segment, path):
         self.calls += 1
-        run_ffmpeg([
-            "-f", "lavfi",
-            "-i", "sine=frequency=440:sample_rate=24000:duration=0.7",
-            "-ac", "1",
-            "-c:a", "libmp3lame",
-            "-b:a", "64k",
-            str(path),
-        ])
+        write_tone(path)
+
+
+class PaddedFakeProvider(FakeProvider):
+    name = "fake-padded"
+
+    def synthesize(self, segment, path):
+        self.calls += 1
+        write_padded_tone(path)
 
 
 class VoiceCacheMigrationTests(unittest.TestCase):
-    def test_previous_manifest_rekeys_unchanged_voice_without_provider_call(self):
+    def test_previous_manifest_rekeys_and_normalizes_without_provider_call(self):
         with tempfile.TemporaryDirectory() as temp_value:
             root = Path(temp_value)
             out = root / "out"
@@ -35,14 +65,7 @@ class VoiceCacheMigrationTests(unittest.TestCase):
             cache.mkdir(parents=True)
             legacy_fp = "legacy-voice-fingerprint"
             legacy_clip = cache / f"{legacy_fp}.mp3"
-            run_ffmpeg([
-                "-f", "lavfi",
-                "-i", "sine=frequency=440:sample_rate=24000:duration=0.7",
-                "-ac", "1",
-                "-c:a", "libmp3lame",
-                "-b:a", "64k",
-                str(legacy_clip),
-            ])
+            write_padded_tone(legacy_clip)
 
             program = {
                 "schema_version": 1,
@@ -82,12 +105,36 @@ class VoiceCacheMigrationTests(unittest.TestCase):
             new_fp = result["mix"]["voice_fingerprints"][0]
             self.assertNotEqual(new_fp, legacy_fp)
             self.assertTrue((cache / f"{new_fp}.mp3").exists())
-            timing_sidecar = cache / f"{new_fp}.json"
-            self.assertTrue(timing_sidecar.exists())
-            self.assertGreater(
-                json.loads(timing_sidecar.read_text(encoding="utf-8"))["measured_duration_ms"],
-                0,
+            timing = json.loads((cache / f"{new_fp}.json").read_text(encoding="utf-8"))
+            self.assertTrue(timing["edge_silence_normalized"])
+            # Provider padding is gone; the deliberate 250 ms internal pause survives.
+            self.assertGreater(timing["measured_duration_ms"], 850)
+            self.assertLess(timing["measured_duration_ms"], 1300)
+
+    def test_new_synthesis_normalizes_only_clip_edges(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            root = Path(temp_value)
+            out = root / "out"
+            program = {
+                "schema_version": 1,
+                "id": "edge-normalization-demo",
+                "title": "Edge normalization demo",
+                "segments": [{"voice": "voice-a", "text": "New sentence."}],
+            }
+            program_path = root / "program.json"
+            program_path.write_text(json.dumps(program), encoding="utf-8")
+
+            provider = PaddedFakeProvider()
+            result = render_program(program_path, out, provider=provider)
+            self.assertEqual(provider.calls, 1)
+            self.assertEqual(result["mix"]["voice_cache_hits"], 0)
+            fingerprint = result["mix"]["voice_fingerprints"][0]
+            timing = json.loads(
+                (out / ".cache" / "voices" / f"{fingerprint}.json").read_text(encoding="utf-8")
             )
+            self.assertTrue(timing["edge_silence_normalized"])
+            self.assertGreater(timing["measured_duration_ms"], 850)
+            self.assertLess(timing["measured_duration_ms"], 1300)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

A real immersive-dialogue render exposed a cadence defect: Edge TTS voice clips commonly contain roughly one second of terminal digital silence. The mixer then adds the authored `pause_after_ms` on top, so a declared 50–150 ms conversational handoff can be perceived as ~1 s or more.

Observed on `La nuit après Orléans` V3: 147/150 rendered segments had terminal silence touching the clip boundary; median detected tail was ~1.02 s at -42 dB. This is provider padding, not authored narrative timing.

## Change

- Normalize only leading/trailing provider silence before a dry voice clip enters the cache.
- Preserve internal pauses by using start-only trimming forward, then the same operation on reversed audio.
- Keep a small safety cushion at both boundaries.
- Bump the synthesis contract fingerprint so normalized clips cannot be confused with old raw clips.
- Migrate unchanged legacy cache entries locally through the normalizer instead of calling the remote TTS provider again.
- Record `edge_silence_normalized: true` in exact timing metadata so measured duration remains authoritative.

No public program schema change, no dialogue-specific product behavior, no overlap/DAW feature.

## Tests

The cache-migration tests now cover:
- local migration of a padded legacy clip with zero provider calls;
- normalization of newly synthesized padded clips;
- preservation of a deliberate 250 ms internal pause while 200 ms leading + 1000 ms trailing provider padding are removed.

The intended consequence is that `pause_after_ms` becomes the real authored inter-segment pause rather than an addition to opaque provider padding.