### PR TITLE
Voice Casting Lab: identity continuity and age-lineage research

### DIFF
--- a/.github/workflows/voice-casting-lab.yml
+++ b/.github/workflows/voice-casting-lab.yml
@@ -1,0 +1,65 @@
+name: Voice Casting Lab
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: Candidate source
+        required: true
+        default: provider
+        type: choice
+        options:
+          - provider
+          - presets
+      stage:
+        description: Campaign stage
+        required: true
+        default: fingerprint
+        type: choice
+        options:
+          - fingerprint
+          - expressive
+          - age
+          - long-form
+          - all
+      limit:
+        description: Optional maximum number of synthesis jobs
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  campaign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install engine
+        run: python -m pip install -e .
+
+      - name: Render campaign
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(voice-lab render --scope "${{ inputs.scope }}" --stage "${{ inputs.stage }}" --out voice-lab-output)
+          if [[ -n "${{ inputs.limit }}" ]]; then
+            args+=(--limit "${{ inputs.limit }}")
+          fi
+          audio-engine "${args[@]}" | tee voice-lab-result.json
+
+      - name: Upload campaign evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: voice-casting-${{ inputs.scope }}-${{ inputs.stage }}
+          path: |
+            voice-lab-output/
+            voice-lab-result.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/VOICES.md
+++ b/docs/VOICES.md
@@ -1,11 +1,13 @@
 # Voice catalog and recommendation policy
 
-Audio Engine separates two questions that must not be confused:
+Audio Engine separates questions that must not be confused:
 
 1. **Is the voice linguistically good enough?**
 2. **Is the voice/preset a good fit for the requested role?**
+3. **Does a character remain recognizably the same across performances?**
+4. **Can two age incarnations plausibly belong to the same character?**
 
-The first question comes from the initial blind French benchmark. The second comes from the subsequent casting experiments.
+The first question comes from the initial blind French benchmark. The second comes from casting experiments. The last two belong to Voice Casting Lab evidence and must not be inferred from labels alone.
 
 ## Quality gate
 
@@ -20,12 +22,38 @@ A voice that sounds attractive but deforms French should not be promoted merely 
 
 The engine deliberately does **not** publish invented historical aggregate scores. It publishes the tested criteria and the presets that were retained through human listening.
 
+## Identity-first casting
+
+A declared `character_id` is cast as a character, not as a sequence of unrelated lines.
+
+The underlying provider voice is the current identity anchor. Once a character has spoken, later segments may change rate, pitch, volume or use another validated preset based on the **same provider voice**, but Audio Engine rejects a silent switch to a different provider voice.
+
+This gives a deterministic engineering guarantee that an emotion or a changed target cannot silently recast the character.
+
+It does not guarantee that the provider voice performs every requested emotion well. Voice Casting Lab measures that expressive envelope.
+
+## Age
+
+The descriptive age vocabulary is:
+
+- `child`;
+- `teen`;
+- `young_adult`;
+- `adult`;
+- `mature`;
+- `older`;
+- `very_old`.
+
+Age suitability and character continuity are separate properties. A voice may be an excellent older voice but a poor older incarnation of a particular younger character.
+
+Audio Engine therefore does not implement automatic cross-voice ageing. Cross-voice age lineages require explicit laboratory evidence before they may become production catalog relationships. See [`VOICE_CASTING_LAB.md`](VOICE_CASTING_LAB.md).
+
 ## Casting model
 
 After the linguistic-quality gate, presets can be ranked against a target profile. The current target dimensions are:
 
 - `gender`;
-- `age` (`child`, `young_adult`, `adult`, `older`);
+- `age`;
 - `energy` 1–5;
 - `authority` 1–5;
 - `warmth` 1–5;
@@ -49,10 +77,22 @@ Example:
 audio-engine recommend --target '{"gender":"male","age":"adult","energy":5,"authority":3,"warmth":4,"tags":["narrateur","vif"]}'
 ```
 
-The result includes the target, quality-validation policy, scoring rules, and the top presets with their provider voice, rate, pitch, volume, traits, tags, and score.
+The result includes the target, quality-validation policy, identity-first casting policy, scoring rules, and the top presets with their provider voice, rate, pitch, volume, traits, tags, and score.
 
-A recommendation is advisory. A consumer may still specify an explicit `preset` or provider `voice` in its program.
+A recommendation is advisory. A consumer may still specify an explicit `preset` or provider `voice` in its program, subject to character identity continuity when the same `character_id` is reused.
+
+## Voice Casting Lab
+
+The lab can inspect the validated preset palette or discover the French voices exposed by the current provider, then plan or render reproducible audition campaigns:
+
+```bash
+audio-engine voice-lab catalog
+audio-engine voice-lab plan --scope provider --stage fingerprint
+audio-engine voice-lab render --scope presets --stage expressive --out voice-lab-output
+```
+
+The lab is evidence gathering, not the production catalog. A generated clip is not automatically a validated voice capability.
 
 ## Why this belongs in Audio Engine
 
-Voice selection is part of the reusable audio-rendering capability, not a property of Audioguide or Learn-it. Consumers describe the desired vocal role; Audio Engine publishes the available validated palette and proposes candidates consistently.
+Voice selection, identity continuity and voice qualification are reusable audio-rendering capabilities, not properties of Audioguide or Learn-it. Consumers describe the desired vocal role and stable character identity; Audio Engine publishes the available validated palette and proposes candidates consistently.

--- a/docs/VOICE_CASTING_LAB.md
+++ b/docs/VOICE_CASTING_LAB.md
@@ -1,0 +1,151 @@
+# Voice Casting Lab
+
+Voice Casting Lab is the experimental qualification layer for synthetic voices. It belongs to Audio Engine because voice discovery, qualification and recommendation are reusable rendering capabilities. It is intentionally outside the normal production render path.
+
+## Product invariant
+
+A story casts a **character**, not an isolated line.
+
+For one declared `character_id`, Audio Engine treats the provider voice as the identity anchor. Rate, pitch, volume and validated presets may vary with performance, but changing the underlying provider voice is a recast and is rejected rather than performed silently.
+
+This gives a hard engineering guarantee: changing emotion or target metadata cannot silently replace the actor voice.
+
+It does **not** claim that every provider voice can perform every emotion convincingly. The lab measures that expressive envelope.
+
+## Age is a lineage problem
+
+Age must not be simulated by a naive pitch rule. A believable age change can affect perceived pitch, stability, breath, rhythm, articulation, resonance and energy.
+
+The lab therefore evaluates seven descriptive age stages:
+
+- `child`
+- `teen`
+- `young_adult`
+- `adult`
+- `mature`
+- `older`
+- `very_old`
+
+The current production renderer does not silently switch provider voices when a character ages. Until a lineage is explicitly qualified, a materially different age incarnation should be treated as a distinct casting decision.
+
+Future production lineage support must be evidence-backed. A pair of voices may only be published as a validated age lineage after listening evidence supports the proposition that listeners can plausibly perceive them as the same character at different ages.
+
+## Campaign stages
+
+The campaign is deliberately progressive rather than a Cartesian explosion.
+
+### 1. Fingerprint
+
+All candidate voices read the same neutral, confidential and authoritative anchors.
+
+Purpose:
+
+- eliminate poor French pronunciation;
+- capture baseline identity;
+- detect redundant candidates;
+- identify promising narrative voices.
+
+### 2. Expressive range
+
+Promising voices are tested against deliberately different dramatic intentions, including joy, tenderness, contained sadness, contained fear, panic, contained anger, polite threat, irony, mystery, fatigue with determination and wonder.
+
+Purpose:
+
+- measure what the voice can actually perform;
+- identify useful limitations;
+- distinguish bad artifacts from useful imperfections;
+- ensure emotion does not destroy recognizability.
+
+### 3. Age / lineage
+
+Candidates use one age-neutral autobiographical anchor. Age suitability and cross-voice continuity are evaluated separately.
+
+Purpose:
+
+- estimate perceived age stage;
+- identify plausible transformations of one provider voice;
+- identify candidate cross-voice lineages for large time jumps.
+
+### 4. Long form
+
+Promising narration voices are tested on sustained prose.
+
+Purpose:
+
+- detect fatigue;
+- detect monotony;
+- measure pronunciation stability and long-form naturalness.
+
+## Evaluation dimensions
+
+Campaign evidence may contain these dimensions:
+
+- `french_pronunciation`
+- `naturalness`
+- `identity_stability`
+- `acting_fit`
+- `age_plausibility`
+- `lineage_continuity`
+- `long_form_fatigue`
+
+Do not manufacture scores for dimensions that were not evaluated.
+
+Human comparison should prefer pairwise or ABX judgments over arbitrary absolute scores. Examples:
+
+- A/B: which performance better conveys contained fear?
+- ABX identity: after hearing the neutral reference, does the emotional performance still sound like the same character?
+- ABX lineage: is it plausible that the older voice is the same character decades later?
+
+Automatic speaker embeddings may later be used as laboratory evidence, but they must not become a required runtime dependency without demonstrated product value.
+
+## Commands
+
+Publish the probe catalog:
+
+```bash
+audio-engine voice-lab catalog
+```
+
+Build a plan over the already validated preset palette without synthesizing audio:
+
+```bash
+audio-engine voice-lab plan --scope presets --stage fingerprint
+```
+
+Discover the French voices exposed by the current provider and build the same fingerprint plan:
+
+```bash
+audio-engine voice-lab plan --scope provider --stage fingerprint
+```
+
+Render a best-effort campaign:
+
+```bash
+audio-engine voice-lab render --scope provider --stage fingerprint --out voice-lab-output
+```
+
+The output contains `campaign.json` plus generated clips. Failures are recorded per job and do not erase successful clips.
+
+## Provider truthfulness
+
+The current Edge provider exposes only these performance controls through Audio Engine:
+
+- `rate`
+- `pitch`
+- `volume`
+
+The lab must not pretend that it has a native `fear`, `anger`, `sadness` or `age` control when the provider does not expose one. Dramatic probe text and tested presets are evidence-gathering mechanisms, not guarantees of acting support.
+
+## Promotion to the production catalog
+
+Lab candidates are not production voices merely because audio was generated.
+
+Promotion requires, at minimum:
+
+1. acceptable French pronunciation;
+2. acceptable naturalness;
+3. explicit evidence for each published character/performance claim;
+4. identity-stability evidence when multiple presets are promoted for one actor voice;
+5. lineage evidence before cross-voice age continuity is published.
+
+The production `voices` catalog remains smaller than the laboratory search space by design.

--- a/src/audio_engine/cli.py
+++ b/src/audio_engine/cli.py
@@ -17,6 +17,7 @@ from .sound.catalog import SOUND_TYPES, public_catalog as public_sound_catalog, 
 from .sound.library import hydrate_sound_library
 from .sound.selection import select_candidates
 from .timing import timing_report
+from .voice_lab import build_campaign, probe_catalog, render_campaign
 from .voices import load_voice_config, public_catalog, recommend_presets
 
 
@@ -37,6 +38,19 @@ def _add_qualify_args(parser, include_type=True):
     )
     parser.add_argument("--tag", action="append", default=[])
     parser.add_argument("--preview-dir", default=None)
+
+
+def _add_voice_lab_args(parser, include_out=False):
+    parser.add_argument("--scope", choices=("presets", "provider"), default="presets")
+    parser.add_argument(
+        "--stage",
+        choices=("fingerprint", "expressive", "age", "long-form", "all"),
+        default="fingerprint",
+    )
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--voices", default=None)
+    if include_out:
+        parser.add_argument("--out", default="voice-lab-output")
 
 
 def build_parser():
@@ -92,6 +106,14 @@ def build_parser():
     recommend.add_argument("--target", required=True)
     recommend.add_argument("--limit", type=int, default=3)
     recommend.add_argument("--voices", default=None)
+
+    voice_lab = sub.add_parser("voice-lab", help="Plan and render reproducible voice casting campaigns")
+    voice_lab_sub = voice_lab.add_subparsers(dest="voice_lab_command", required=True)
+    voice_lab_sub.add_parser("catalog", help="Publish the voice-lab probe catalog")
+    voice_lab_plan = voice_lab_sub.add_parser("plan", help="Build a campaign plan without synthesizing audio")
+    _add_voice_lab_args(voice_lab_plan)
+    voice_lab_render = voice_lab_sub.add_parser("render", help="Render a best-effort voice campaign")
+    _add_voice_lab_args(voice_lab_render, include_out=True)
 
     sounds = sub.add_parser("sounds", help="Publish the validated production sound meta-index")
     sounds.add_argument("--catalog", default=None)
@@ -180,6 +202,26 @@ def main(argv=None):
                 raise ValueError("--target must be a JSON object")
             config, _ = load_voice_config(args.voices)
             result = recommend_presets(target, config, args.limit)
+        elif args.command == "voice-lab":
+            if args.voice_lab_command == "catalog":
+                result = probe_catalog()
+            else:
+                config, _ = load_voice_config(args.voices)
+                if args.voice_lab_command == "plan":
+                    result = build_campaign(
+                        voice_config=config,
+                        scope=args.scope,
+                        stage=args.stage,
+                        limit=args.limit,
+                    )
+                else:
+                    result = render_campaign(
+                        args.out,
+                        voice_config=config,
+                        scope=args.scope,
+                        stage=args.stage,
+                        limit=args.limit,
+                    )
         elif args.command == "sounds":
             if args.id:
                 entry, _ = sound_info(args.id, args.catalog)

--- a/src/audio_engine/providers/edge.py
+++ b/src/audio_engine/providers/edge.py
@@ -4,9 +4,11 @@ import edge_tts
 
 _PATCHED = False
 
+
 def _locale_from_voice(voice):
     match = re.match(r"^([a-z]{2,3}-[A-Z]{2})-", voice or "")
     return match.group(1) if match else None
+
 
 def patch_ssml_locale():
     global _PATCHED
@@ -31,12 +33,33 @@ def patch_ssml_locale():
     finally:
         _PATCHED = True
 
+
 class EdgeProvider:
     name = "edge"
     processing = "remote"
+    expressive_controls = ("rate", "pitch", "volume")
 
     def __init__(self):
         patch_ssml_locale()
+
+    async def list_voices_async(self, locale_prefix=None):
+        voices = await edge_tts.list_voices()
+        normalized = []
+        for item in voices:
+            short_name = item.get("ShortName") or item.get("Name")
+            locale = item.get("Locale") or _locale_from_voice(short_name)
+            if locale_prefix and not str(locale or "").startswith(locale_prefix):
+                continue
+            normalized.append({
+                "voice": short_name,
+                "locale": locale,
+                "gender": str(item.get("Gender") or "").lower() or None,
+                "friendly_name": item.get("FriendlyName"),
+            })
+        return sorted(normalized, key=lambda item: (item.get("locale") or "", item.get("voice") or ""))
+
+    def list_voices(self, locale_prefix=None):
+        return asyncio.run(self.list_voices_async(locale_prefix=locale_prefix))
 
     async def synthesize_async(self, segment, path):
         last_error = None

--- a/src/audio_engine/voice_lab.py
+++ b/src/audio_engine/voice_lab.py
@@ -1,0 +1,283 @@
+import json
+import re
+from pathlib import Path
+
+from .providers.edge import EdgeProvider
+from .voices import load_voice_config
+
+
+AGE_STAGES = ("child", "teen", "young_adult", "adult", "mature", "older", "very_old")
+
+PROBES = (
+    {
+        "id": "identity-neutral",
+        "stage": "fingerprint",
+        "kind": "identity",
+        "intention": "neutral",
+        "text": "À l'aube, personne dans la ville ne savait encore ce qui allait se produire.",
+    },
+    {
+        "id": "identity-confidence",
+        "stage": "fingerprint",
+        "kind": "identity",
+        "intention": "confidence",
+        "text": "Approchez. Ce que je vais vous dire ne doit sortir d'ici sous aucun prétexte.",
+    },
+    {
+        "id": "identity-authority",
+        "stage": "fingerprint",
+        "kind": "identity",
+        "intention": "authority",
+        "text": "Vous ferez exactement ce que je vous demande, et personne ne quittera sa position.",
+    },
+    {
+        "id": "emotion-joy",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "joy",
+        "text": "Vous êtes là ! Je n'osais plus croire que nous nous reverrions un jour.",
+    },
+    {
+        "id": "emotion-tenderness",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "tenderness",
+        "text": "Ne vous inquiétez pas. Je resterai près de vous jusqu'au matin.",
+    },
+    {
+        "id": "emotion-sadness-contained",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "sadness-contained",
+        "text": "Il était mon frère. Je n'en parlerai pas davantage.",
+    },
+    {
+        "id": "emotion-fear-contained",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "fear-contained",
+        "text": "Restez derrière moi. Quoi qu'il arrive, surtout, ne faites aucun bruit.",
+    },
+    {
+        "id": "emotion-panic",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "panic",
+        "text": "Courez ! Ils arrivent ! Fermez la porte, vite !",
+    },
+    {
+        "id": "emotion-anger-contained",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "anger-contained",
+        "text": "Je vous avais donné ma parole. Vous venez de me donner une raison de la reprendre.",
+    },
+    {
+        "id": "emotion-threat-polite",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "threat-polite",
+        "text": "Je vous conseille très sincèrement de reconsidérer votre réponse.",
+    },
+    {
+        "id": "emotion-irony",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "irony",
+        "text": "Évidemment. Votre plan était parfait. C'est sans doute pour cela que tout brûle.",
+    },
+    {
+        "id": "emotion-mystery",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "mystery",
+        "text": "Depuis trois nuits, la même lumière apparaît derrière cette fenêtre condamnée.",
+    },
+    {
+        "id": "emotion-fatigue-determined",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "fatigue-determined",
+        "text": "Je n'ai presque plus de forces. Mais nous irons jusqu'au bout.",
+    },
+    {
+        "id": "emotion-wonder",
+        "stage": "expressive",
+        "kind": "performance",
+        "intention": "wonder",
+        "text": "Regardez... On distingue toute la vallée, jusqu'aux montagnes derrière la brume.",
+    },
+    {
+        "id": "age-anchor",
+        "stage": "age",
+        "kind": "age-lineage",
+        "intention": "neutral",
+        "text": "Je me souviens très bien de cette maison. J'y revenais chaque été, toujours par le même chemin.",
+    },
+    {
+        "id": "long-form",
+        "stage": "long-form",
+        "kind": "endurance",
+        "intention": "narration",
+        "text": (
+            "La route suivait encore la rivière lorsque les premières maisons apparurent. "
+            "À cette heure, les volets s'ouvraient un à un et le marché commençait à gagner la place. "
+            "Rien, à première vue, ne distinguait cette matinée des précédentes. Pourtant, avant midi, "
+            "un événement allait changer durablement la mémoire de ceux qui vivaient ici."
+        ),
+    },
+)
+
+
+def probe_catalog():
+    return {
+        "version": 1,
+        "age_stages": list(AGE_STAGES),
+        "principles": {
+            "identity_first": True,
+            "emotion_never_implies_recast": True,
+            "age_is_a_lineage_problem": True,
+            "runtime_ml_required": False,
+            "provider_controls_are_measured_not_assumed": True,
+        },
+        "probes": list(PROBES),
+    }
+
+
+def _slug(value):
+    value = re.sub(r"[^a-zA-Z0-9._-]+", "-", str(value)).strip("-")
+    return value or "voice"
+
+
+def _preset_candidates(voice_config):
+    result = []
+    for preset in voice_config.get("presets", []):
+        result.append({
+            "candidate_id": preset["id"],
+            "source": "validated-preset",
+            "voice": preset["voice"],
+            "rate": preset.get("rate", "+0%"),
+            "pitch": preset.get("pitch", "+0Hz"),
+            "volume": preset.get("volume", "+0%"),
+            "traits": preset.get("traits", {}),
+            "tags": preset.get("tags", []),
+        })
+    return result
+
+
+def _provider_candidates(provider, locale_prefix="fr-"):
+    return [
+        {
+            "candidate_id": item["voice"],
+            "source": "provider-voice",
+            "voice": item["voice"],
+            "rate": "+0%",
+            "pitch": "+0Hz",
+            "volume": "+0%",
+            "provider_metadata": item,
+        }
+        for item in provider.list_voices(locale_prefix=locale_prefix)
+    ]
+
+
+def build_campaign(voice_config=None, provider=None, scope="presets", stage="fingerprint", limit=None):
+    if stage not in {"fingerprint", "expressive", "age", "long-form", "all"}:
+        raise ValueError("stage must be fingerprint, expressive, age, long-form, or all")
+    provider = provider or EdgeProvider()
+    if voice_config is None:
+        voice_config, _ = load_voice_config()
+
+    if scope == "presets":
+        candidates = _preset_candidates(voice_config)
+    elif scope == "provider":
+        candidates = _provider_candidates(provider)
+    else:
+        raise ValueError("scope must be presets or provider")
+
+    probes = list(PROBES) if stage == "all" else [probe for probe in PROBES if probe["stage"] == stage]
+    jobs = []
+    for candidate in candidates:
+        for probe in probes:
+            job = {
+                "id": f"{_slug(candidate['candidate_id'])}--{probe['id']}",
+                "candidate": candidate,
+                "probe": probe,
+            }
+            jobs.append(job)
+            if limit is not None and len(jobs) >= limit:
+                break
+        if limit is not None and len(jobs) >= limit:
+            break
+
+    return {
+        "version": 1,
+        "scope": scope,
+        "stage": stage,
+        "provider": provider.name,
+        "provider_processing": provider.processing,
+        "provider_expressive_controls": list(getattr(provider, "expressive_controls", ())),
+        "candidate_count": len(candidates),
+        "probe_count": len(probes),
+        "job_count": len(jobs),
+        "jobs": jobs,
+        "evaluation": {
+            "required_dimensions": [
+                "french_pronunciation",
+                "naturalness",
+                "identity_stability",
+                "acting_fit",
+                "age_plausibility",
+                "lineage_continuity",
+                "long_form_fatigue",
+            ],
+            "preferred_comparison": "pairwise-or-abx",
+            "note": "Scores describe observed campaign evidence; do not infer untested emotions or age continuity.",
+        },
+    }
+
+
+def render_campaign(output_dir, voice_config=None, provider=None, scope="presets", stage="fingerprint", limit=None):
+    provider = provider or EdgeProvider()
+    plan = build_campaign(
+        voice_config=voice_config,
+        provider=provider,
+        scope=scope,
+        stage=stage,
+        limit=limit,
+    )
+    output_dir = Path(output_dir)
+    clips_dir = output_dir / "clips"
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    rendered = []
+    failures = []
+    for job in plan["jobs"]:
+        candidate = job["candidate"]
+        segment = {
+            "text": job["probe"]["text"],
+            "voice": candidate["voice"],
+            "rate": candidate.get("rate", "+0%"),
+            "pitch": candidate.get("pitch", "+0Hz"),
+            "volume": candidate.get("volume", "+0%"),
+        }
+        filename = f"{_slug(job['id'])}.mp3"
+        path = clips_dir / filename
+        try:
+            provider.synthesize(segment, path)
+            rendered.append({"job_id": job["id"], "file": f"clips/{filename}"})
+        except Exception as exc:
+            failures.append({"job_id": job["id"], "error": str(exc)})
+
+    result = {
+        **plan,
+        "status": "success" if not failures else ("partial" if rendered else "failed"),
+        "rendered_count": len(rendered),
+        "failure_count": len(failures),
+        "rendered": rendered,
+        "failures": failures,
+    }
+    (output_dir / "campaign.json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return result

--- a/src/audio_engine/voices.py
+++ b/src/audio_engine/voices.py
@@ -1,7 +1,15 @@
 import json
 from pathlib import Path
 
-AGE_ORDER = {"child": 0, "young_adult": 1, "adult": 2, "older": 3}
+AGE_ORDER = {
+    "child": 0,
+    "teen": 1,
+    "young_adult": 2,
+    "adult": 3,
+    "mature": 4,
+    "older": 5,
+    "very_old": 6,
+}
 NUMERIC_TRAITS = {
     "energy": 1.5,
     "authority": 1.4,
@@ -12,6 +20,13 @@ NUMERIC_TRAITS = {
 GENDER_MISMATCH_PENALTY = 25.0
 AGE_DISTANCE_PENALTY = 7.0
 TAG_MATCH_BONUS = 2.0
+CASTING_POLICY = {
+    "identity_first": True,
+    "identity_key": "provider_voice",
+    "emotion_may_change_preset_not_voice": True,
+    "silent_recast": "forbidden",
+    "age_lineage": "lab-qualified; explicit production lineage contract pending validation",
+}
 QUALITY_VALIDATION = {
     "origin": "initial blind French voice benchmark and subsequent human casting tests",
     "principle": "language quality is checked before role fit",
@@ -70,6 +85,7 @@ def public_catalog(voice_config):
         "version": voice_config.get("version"),
         "description": voice_config.get("description"),
         "quality_validation": voice_config.get("quality_validation", QUALITY_VALIDATION),
+        "casting_policy": CASTING_POLICY,
         "selection_rules": selection_rules(),
         "presets": voice_config.get("presets", []),
     }
@@ -111,6 +127,7 @@ def recommend_presets(target, voice_config, limit=3):
     return {
         "target": target,
         "quality_validation": voice_config.get("quality_validation", QUALITY_VALIDATION),
+        "casting_policy": CASTING_POLICY,
         "selection_rules": selection_rules(),
         "recommendations": [
             {
@@ -128,6 +145,16 @@ def choose_preset(target, presets):
     return ranked[0][1], ranked
 
 
+def _identity_from_resolution(voice, rate, pitch, volume, resolved_preset):
+    return {
+        "voice": voice,
+        "rate": rate,
+        "pitch": pitch,
+        "volume": volume,
+        "resolved_preset": resolved_preset,
+    }
+
+
 def resolve_segments(program, voice_config):
     presets = voice_config.get("presets", [])
     by_id = {preset["id"]: preset for preset in presets}
@@ -136,7 +163,8 @@ def resolve_segments(program, voice_config):
     for index, segment in enumerate(program["segments"], start=1):
         explicit_voice = segment.get("voice")
         preset_id = segment.get("preset")
-        character_id = segment.get("character_id") or f"segment-{index}"
+        explicit_character_id = segment.get("character_id")
+        character_id = explicit_character_id or f"segment-{index}"
         alternatives = []
 
         if explicit_voice:
@@ -145,25 +173,46 @@ def resolve_segments(program, voice_config):
             pitch = segment.get("pitch", "+0Hz")
             volume = segment.get("volume", "+0%")
             resolved_preset = None
-        else:
-            if preset_id:
-                if preset_id not in by_id:
-                    raise ValueError(f"Unknown voice preset: {preset_id}")
-                preset = by_id[preset_id]
-            elif character_id in character_cast:
-                preset = character_cast[character_id]
-            else:
-                preset, ranked = choose_preset(segment.get("target", {}), presets)
-                character_cast[character_id] = preset
-                alternatives = [
-                    {"preset": candidate["id"], "score": round(score, 3)}
-                    for score, candidate in ranked
-                ]
+        elif preset_id:
+            if preset_id not in by_id:
+                raise ValueError(f"Unknown voice preset: {preset_id}")
+            preset = by_id[preset_id]
             voice = preset["voice"]
             rate = segment.get("rate", preset.get("rate", "+0%"))
             pitch = segment.get("pitch", preset.get("pitch", "+0Hz"))
             volume = segment.get("volume", preset.get("volume", "+0%"))
             resolved_preset = preset["id"]
+        elif explicit_character_id and character_id in character_cast:
+            identity = character_cast[character_id]
+            voice = identity["voice"]
+            rate = segment.get("rate", identity["rate"])
+            pitch = segment.get("pitch", identity["pitch"])
+            volume = segment.get("volume", identity["volume"])
+            resolved_preset = identity["resolved_preset"]
+        else:
+            preset, ranked = choose_preset(segment.get("target", {}), presets)
+            voice = preset["voice"]
+            rate = segment.get("rate", preset.get("rate", "+0%"))
+            pitch = segment.get("pitch", preset.get("pitch", "+0Hz"))
+            volume = segment.get("volume", preset.get("volume", "+0%"))
+            resolved_preset = preset["id"]
+            alternatives = [
+                {"preset": candidate["id"], "score": round(score, 3)}
+                for score, candidate in ranked
+            ]
+
+        if explicit_character_id:
+            previous = character_cast.get(character_id)
+            if previous and previous["voice"] != voice:
+                raise ValueError(
+                    f"Character {character_id!r} cannot silently change provider voice "
+                    f"from {previous['voice']} to {voice}; use a distinct age incarnation until "
+                    "an age lineage has been explicitly qualified"
+                )
+            if previous is None:
+                character_cast[character_id] = _identity_from_resolution(
+                    voice, rate, pitch, volume, resolved_preset
+                )
 
         resolved.append({
             **segment,
@@ -173,6 +222,7 @@ def resolve_segments(program, voice_config):
             "rate": rate,
             "pitch": pitch,
             "volume": volume,
+            "casting_identity": voice if explicit_character_id else None,
             "casting_alternatives": alternatives,
         })
     return resolved

--- a/tests/test_voice_lab.py
+++ b/tests/test_voice_lab.py
@@ -1,6 +1,6 @@
+import tempfile
+import unittest
 from pathlib import Path
-
-import pytest
 
 from audio_engine.voice_lab import AGE_STAGES, build_campaign, probe_catalog, render_campaign
 from audio_engine.voices import resolve_segments
@@ -58,84 +58,90 @@ class FakeProvider:
         Path(path).write_bytes(b"fake-mp3")
 
 
-def test_probe_catalog_separates_identity_emotion_and_age():
-    catalog = probe_catalog()
-    assert catalog["principles"]["identity_first"] is True
-    assert catalog["principles"]["emotion_never_implies_recast"] is True
-    assert tuple(catalog["age_stages"]) == AGE_STAGES
-    assert any(item["kind"] == "age-lineage" for item in catalog["probes"])
-    assert any(item["kind"] == "performance" for item in catalog["probes"])
+class VoiceLabTests(unittest.TestCase):
+    def test_probe_catalog_separates_identity_emotion_and_age(self):
+        catalog = probe_catalog()
+        self.assertTrue(catalog["principles"]["identity_first"])
+        self.assertTrue(catalog["principles"]["emotion_never_implies_recast"])
+        self.assertEqual(tuple(catalog["age_stages"]), AGE_STAGES)
+        self.assertTrue(any(item["kind"] == "age-lineage" for item in catalog["probes"]))
+        self.assertTrue(any(item["kind"] == "performance" for item in catalog["probes"]))
+
+    def test_campaign_plan_can_scan_provider_french_voices_without_invented_traits(self):
+        plan = build_campaign(
+            voice_config=VOICE_CONFIG,
+            provider=FakeProvider(),
+            scope="provider",
+            stage="fingerprint",
+        )
+        self.assertEqual(plan["candidate_count"], 1)
+        self.assertEqual(plan["probe_count"], 3)
+        self.assertEqual(plan["job_count"], 3)
+        self.assertEqual(plan["jobs"][0]["candidate"]["voice"], "fr-FR-OneNeural")
+        self.assertNotIn("traits", plan["jobs"][0]["candidate"])
+
+    def test_render_campaign_is_best_effort_and_persists_manifest(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            root = Path(temp_value)
+            result = render_campaign(
+                root,
+                voice_config=VOICE_CONFIG,
+                provider=FakeProvider(),
+                scope="presets",
+                stage="age",
+            )
+            self.assertEqual(result["status"], "success")
+            self.assertEqual(result["rendered_count"], len(VOICE_CONFIG["presets"]))
+            self.assertTrue((root / "campaign.json").exists())
+            self.assertEqual(
+                len(list((root / "clips").glob("*.mp3"))),
+                len(VOICE_CONFIG["presets"]),
+            )
+
+    def test_character_target_changes_do_not_recast_identity(self):
+        program = {
+            "segments": [
+                {
+                    "character_id": "captain",
+                    "target": {"gender": "male", "age": "adult", "energy": 2},
+                    "text": "Calme.",
+                },
+                {
+                    "character_id": "captain",
+                    "target": {"gender": "male", "age": "adult", "energy": 5, "tags": ["urgent"]},
+                    "text": "Urgence.",
+                    "rate": "+15%",
+                },
+            ]
+        }
+        resolved = resolve_segments(program, VOICE_CONFIG)
+        self.assertEqual(resolved[0]["voice"], resolved[1]["voice"])
+        self.assertEqual(resolved[1]["rate"], "+15%")
+        self.assertEqual(resolved[0]["casting_identity"], "fr-FR-ActorNeural")
+
+    def test_same_provider_voice_may_change_preset_for_performance(self):
+        program = {
+            "segments": [
+                {"character_id": "captain", "preset": "actor-calm", "text": "Calme."},
+                {"character_id": "captain", "preset": "actor-intense", "text": "Courez !"},
+            ]
+        }
+        resolved = resolve_segments(program, VOICE_CONFIG)
+        self.assertEqual(resolved[0]["voice"], "fr-FR-ActorNeural")
+        self.assertEqual(resolved[1]["voice"], "fr-FR-ActorNeural")
+        self.assertEqual(resolved[0]["resolved_preset"], "actor-calm")
+        self.assertEqual(resolved[1]["resolved_preset"], "actor-intense")
+
+    def test_different_provider_voice_for_same_character_is_rejected(self):
+        program = {
+            "segments": [
+                {"character_id": "captain", "preset": "actor-calm", "text": "Calme."},
+                {"character_id": "captain", "preset": "other-actor", "text": "Autre voix."},
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, "cannot silently change provider voice"):
+            resolve_segments(program, VOICE_CONFIG)
 
 
-def test_campaign_plan_can_scan_provider_french_voices_without_invented_traits():
-    plan = build_campaign(
-        voice_config=VOICE_CONFIG,
-        provider=FakeProvider(),
-        scope="provider",
-        stage="fingerprint",
-    )
-    assert plan["candidate_count"] == 1
-    assert plan["probe_count"] == 3
-    assert plan["job_count"] == 3
-    assert plan["jobs"][0]["candidate"]["voice"] == "fr-FR-OneNeural"
-    assert "traits" not in plan["jobs"][0]["candidate"]
-
-
-def test_render_campaign_is_best_effort_and_persists_manifest(tmp_path):
-    result = render_campaign(
-        tmp_path,
-        voice_config=VOICE_CONFIG,
-        provider=FakeProvider(),
-        scope="presets",
-        stage="age",
-    )
-    assert result["status"] == "success"
-    assert result["rendered_count"] == len(VOICE_CONFIG["presets"])
-    assert (tmp_path / "campaign.json").exists()
-    assert len(list((tmp_path / "clips").glob("*.mp3"))) == len(VOICE_CONFIG["presets"])
-
-
-def test_character_target_changes_do_not_recast_identity():
-    program = {
-        "segments": [
-            {
-                "character_id": "captain",
-                "target": {"gender": "male", "age": "adult", "energy": 2},
-                "text": "Calme.",
-            },
-            {
-                "character_id": "captain",
-                "target": {"gender": "male", "age": "adult", "energy": 5, "tags": ["urgent"]},
-                "text": "Urgence.",
-                "rate": "+15%",
-            },
-        ]
-    }
-    resolved = resolve_segments(program, VOICE_CONFIG)
-    assert resolved[0]["voice"] == resolved[1]["voice"]
-    assert resolved[1]["rate"] == "+15%"
-    assert resolved[0]["casting_identity"] == "fr-FR-ActorNeural"
-
-
-def test_same_provider_voice_may_change_preset_for_performance():
-    program = {
-        "segments": [
-            {"character_id": "captain", "preset": "actor-calm", "text": "Calme."},
-            {"character_id": "captain", "preset": "actor-intense", "text": "Courez !"},
-        ]
-    }
-    resolved = resolve_segments(program, VOICE_CONFIG)
-    assert resolved[0]["voice"] == resolved[1]["voice"] == "fr-FR-ActorNeural"
-    assert resolved[0]["resolved_preset"] == "actor-calm"
-    assert resolved[1]["resolved_preset"] == "actor-intense"
-
-
-def test_different_provider_voice_for_same_character_is_rejected():
-    program = {
-        "segments": [
-            {"character_id": "captain", "preset": "actor-calm", "text": "Calme."},
-            {"character_id": "captain", "preset": "other-actor", "text": "Autre voix."},
-        ]
-    }
-    with pytest.raises(ValueError, match="cannot silently change provider voice"):
-        resolve_segments(program, VOICE_CONFIG)
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_voice_lab.py
+++ b/tests/test_voice_lab.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+import pytest
+
+from audio_engine.voice_lab import AGE_STAGES, build_campaign, probe_catalog, render_campaign
+from audio_engine.voices import resolve_segments
+
+
+VOICE_CONFIG = {
+    "version": 1,
+    "presets": [
+        {
+            "id": "actor-calm",
+            "voice": "fr-FR-ActorNeural",
+            "rate": "+0%",
+            "pitch": "+0Hz",
+            "volume": "+0%",
+            "traits": {"gender": "male", "age": "adult", "energy": 2},
+            "tags": ["calm"],
+        },
+        {
+            "id": "actor-intense",
+            "voice": "fr-FR-ActorNeural",
+            "rate": "+12%",
+            "pitch": "+5Hz",
+            "volume": "+4%",
+            "traits": {"gender": "male", "age": "adult", "energy": 5},
+            "tags": ["urgent"],
+        },
+        {
+            "id": "other-actor",
+            "voice": "fr-FR-OtherNeural",
+            "rate": "+0%",
+            "pitch": "+0Hz",
+            "volume": "+0%",
+            "traits": {"gender": "male", "age": "adult", "energy": 3},
+            "tags": [],
+        },
+    ],
+}
+
+
+class FakeProvider:
+    name = "fake"
+    processing = "local-test"
+    expressive_controls = ("rate", "pitch", "volume")
+
+    def list_voices(self, locale_prefix=None):
+        voices = [
+            {"voice": "fr-FR-OneNeural", "locale": "fr-FR", "gender": "female", "friendly_name": "One"},
+            {"voice": "en-US-TwoNeural", "locale": "en-US", "gender": "male", "friendly_name": "Two"},
+        ]
+        if locale_prefix:
+            voices = [item for item in voices if item["locale"].startswith(locale_prefix)]
+        return voices
+
+    def synthesize(self, segment, path):
+        Path(path).write_bytes(b"fake-mp3")
+
+
+def test_probe_catalog_separates_identity_emotion_and_age():
+    catalog = probe_catalog()
+    assert catalog["principles"]["identity_first"] is True
+    assert catalog["principles"]["emotion_never_implies_recast"] is True
+    assert tuple(catalog["age_stages"]) == AGE_STAGES
+    assert any(item["kind"] == "age-lineage" for item in catalog["probes"])
+    assert any(item["kind"] == "performance" for item in catalog["probes"])
+
+
+def test_campaign_plan_can_scan_provider_french_voices_without_invented_traits():
+    plan = build_campaign(
+        voice_config=VOICE_CONFIG,
+        provider=FakeProvider(),
+        scope="provider",
+        stage="fingerprint",
+    )
+    assert plan["candidate_count"] == 1
+    assert plan["probe_count"] == 3
+    assert plan["job_count"] == 3
+    assert plan["jobs"][0]["candidate"]["voice"] == "fr-FR-OneNeural"
+    assert "traits" not in plan["jobs"][0]["candidate"]
+
+
+def test_render_campaign_is_best_effort_and_persists_manifest(tmp_path):
+    result = render_campaign(
+        tmp_path,
+        voice_config=VOICE_CONFIG,
+        provider=FakeProvider(),
+        scope="presets",
+        stage="age",
+    )
+    assert result["status"] == "success"
+    assert result["rendered_count"] == len(VOICE_CONFIG["presets"])
+    assert (tmp_path / "campaign.json").exists()
+    assert len(list((tmp_path / "clips").glob("*.mp3"))) == len(VOICE_CONFIG["presets"])
+
+
+def test_character_target_changes_do_not_recast_identity():
+    program = {
+        "segments": [
+            {
+                "character_id": "captain",
+                "target": {"gender": "male", "age": "adult", "energy": 2},
+                "text": "Calme.",
+            },
+            {
+                "character_id": "captain",
+                "target": {"gender": "male", "age": "adult", "energy": 5, "tags": ["urgent"]},
+                "text": "Urgence.",
+                "rate": "+15%",
+            },
+        ]
+    }
+    resolved = resolve_segments(program, VOICE_CONFIG)
+    assert resolved[0]["voice"] == resolved[1]["voice"]
+    assert resolved[1]["rate"] == "+15%"
+    assert resolved[0]["casting_identity"] == "fr-FR-ActorNeural"
+
+
+def test_same_provider_voice_may_change_preset_for_performance():
+    program = {
+        "segments": [
+            {"character_id": "captain", "preset": "actor-calm", "text": "Calme."},
+            {"character_id": "captain", "preset": "actor-intense", "text": "Courez !"},
+        ]
+    }
+    resolved = resolve_segments(program, VOICE_CONFIG)
+    assert resolved[0]["voice"] == resolved[1]["voice"] == "fr-FR-ActorNeural"
+    assert resolved[0]["resolved_preset"] == "actor-calm"
+    assert resolved[1]["resolved_preset"] == "actor-intense"
+
+
+def test_different_provider_voice_for_same_character_is_rejected():
+    program = {
+        "segments": [
+            {"character_id": "captain", "preset": "actor-calm", "text": "Calme."},
+            {"character_id": "captain", "preset": "other-actor", "text": "Autre voix."},
+        ]
+    }
+    with pytest.raises(ValueError, match="cannot silently change provider voice"):
+        resolve_segments(program, VOICE_CONFIG)


### PR DESCRIPTION
## Why
Build a reusable voice-casting research layer without moving experimental complexity into the production renderer.

## What changes
- adds `voice-lab` probe catalog, campaign planning and best-effort rendering
- can scan the validated preset palette or discover current French Edge voices
- adds a manual GitHub Actions campaign workflow that uploads generated evidence
- makes character identity first-class: the same `character_id` cannot silently switch provider voice
- still allows performance changes through rate/pitch/volume or another preset backed by the same provider voice
- expands descriptive age stages for research and recommendation
- documents age as a lineage problem rather than a pitch transform
- adds offline tests for campaign generation, rendering harness and identity lock

## Deliberate non-goals
- no automatic cross-voice ageing in production yet
- no fabricated emotion/age scores
- no ML dependency in runtime
- no claim that Edge exposes native emotion controls

## Promotion rule
Cross-voice age lineages must be backed by ABX/pairwise listening evidence before becoming production catalog relationships.