### PR TITLE
Voice Lab: multilingual discovery and pairwise evaluation

### DIFF
--- a/.github/workflows/voice-casting-lab.yml
+++ b/.github/workflows/voice-casting-lab.yml
@@ -11,6 +11,14 @@ on:
         options:
           - provider
           - presets
+      candidate_set:
+        description: Provider discovery set
+        required: true
+        default: fr
+        type: choice
+        options:
+          - fr
+          - fr-plus-multilingual
       stage:
         description: Campaign stage
         required: true
@@ -47,7 +55,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          args=(voice-lab render --scope "${{ inputs.scope }}" --stage "${{ inputs.stage }}" --out voice-lab-output)
+          args=(
+            voice-lab render
+            --scope "${{ inputs.scope }}"
+            --stage "${{ inputs.stage }}"
+            --candidate-set "${{ inputs.candidate_set }}"
+            --out voice-lab-output
+          )
           if [[ -n "${{ inputs.limit }}" ]]; then
             args+=(--limit "${{ inputs.limit }}")
           fi
@@ -57,7 +71,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: voice-casting-${{ inputs.scope }}-${{ inputs.stage }}
+          name: voice-casting-${{ inputs.scope }}-${{ inputs.candidate_set }}-${{ inputs.stage }}
           path: |
             voice-lab-output/
             voice-lab-result.json

--- a/docs/VOICE_CASTING_LAB.md
+++ b/docs/VOICE_CASTING_LAB.md
@@ -76,6 +76,16 @@ Purpose:
 - detect monotony;
 - measure pronunciation stability and long-form naturalness.
 
+## Candidate discovery
+
+Two provider discovery sets are supported.
+
+`fr` is the conservative baseline: only voices whose provider locale starts with `fr-`.
+
+`fr-plus-multilingual` expands the laboratory search space with every provider voice whose name contains `Multilingual`, even when its native provider locale is not French. These extra voices are **candidates only**. The engine does not assume that a multilingual model speaks French well merely because the provider labels it multilingual; French pronunciation remains an eliminatory listening gate.
+
+This lets the lab search a much broader actor palette without weakening production quality policy.
+
 ## Evaluation dimensions
 
 Campaign evidence may contain these dimensions:
@@ -96,7 +106,7 @@ Human comparison should prefer pairwise or ABX judgments over arbitrary absolute
 - ABX identity: after hearing the neutral reference, does the emotional performance still sound like the same character?
 - ABX lineage: is it plausible that the older voice is the same character decades later?
 
-Automatic speaker embeddings may later be used as laboratory evidence, but they must not become a required runtime dependency without demonstrated product value.
+Automatic speaker embeddings or acoustic features may be used as laboratory pre-screen evidence, but they must not become a required runtime dependency without demonstrated product value. Objective pre-screening is never promoted as an artistic score.
 
 ## Commands
 
@@ -112,19 +122,45 @@ Build a plan over the already validated preset palette without synthesizing audi
 audio-engine voice-lab plan --scope presets --stage fingerprint
 ```
 
-Discover the French voices exposed by the current provider and build the same fingerprint plan:
+Discover the French voices exposed by the current provider:
 
 ```bash
-audio-engine voice-lab plan --scope provider --stage fingerprint
+audio-engine voice-lab plan --scope provider --stage fingerprint --candidate-set fr
+```
+
+Expand discovery to French-locale plus multilingual provider voices:
+
+```bash
+audio-engine voice-lab plan --scope provider --stage fingerprint --candidate-set fr-plus-multilingual
 ```
 
 Render a best-effort campaign:
 
 ```bash
-audio-engine voice-lab render --scope provider --stage fingerprint --out voice-lab-output
+audio-engine voice-lab render --scope provider --stage fingerprint --candidate-set fr-plus-multilingual --out voice-lab-output
 ```
 
 The output contains `campaign.json` plus generated clips. Failures are recorded per job and do not erase successful clips.
+
+Generate a static pairwise listening bundle from one rendered campaign:
+
+```bash
+audio-engine voice-lab pairwise voice-lab-output/campaign.json \
+  --probe identity-neutral \
+  --dimension french_pronunciation \
+  --rounds 4 \
+  --out voice-pairwise
+```
+
+The bundle contains:
+
+- the minimal set of audio clips used by the comparisons;
+- `pairwise-plan.json` with the deterministic comparison schedule;
+- `index.html`, a dependency-free local player that exports `pairwise-results.json`.
+
+By default comparisons are stratified by perceived provider gender when metadata exists, limiting an obvious source of comparison bias. `--cross-gender` disables this stratification when a global comparison is intentionally desired.
+
+The planner does not contain a hidden winner and never converts provider metadata or acoustic pre-screening into an artistic decision.
 
 ## Provider truthfulness
 

--- a/src/audio_engine/cli.py
+++ b/src/audio_engine/cli.py
@@ -17,7 +17,14 @@ from .sound.catalog import SOUND_TYPES, public_catalog as public_sound_catalog, 
 from .sound.library import hydrate_sound_library
 from .sound.selection import select_candidates
 from .timing import timing_report
-from .voice_lab import build_campaign, probe_catalog, render_campaign
+from .voice_lab import (
+    PAIRWISE_DIMENSIONS,
+    PROVIDER_CANDIDATE_SETS,
+    build_campaign,
+    probe_catalog,
+    render_campaign,
+    write_pairwise_bundle,
+)
 from .voices import load_voice_config, public_catalog, recommend_presets
 
 
@@ -46,6 +53,12 @@ def _add_voice_lab_args(parser, include_out=False):
         "--stage",
         choices=("fingerprint", "expressive", "age", "long-form", "all"),
         default="fingerprint",
+    )
+    parser.add_argument(
+        "--candidate-set",
+        choices=PROVIDER_CANDIDATE_SETS,
+        default="fr",
+        help="Provider discovery set; ignored when --scope presets",
     )
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--voices", default=None)
@@ -107,13 +120,27 @@ def build_parser():
     recommend.add_argument("--limit", type=int, default=3)
     recommend.add_argument("--voices", default=None)
 
-    voice_lab = sub.add_parser("voice-lab", help="Plan and render reproducible voice casting campaigns")
+    voice_lab = sub.add_parser("voice-lab", help="Plan, render and evaluate reproducible voice casting campaigns")
     voice_lab_sub = voice_lab.add_subparsers(dest="voice_lab_command", required=True)
     voice_lab_sub.add_parser("catalog", help="Publish the voice-lab probe catalog")
     voice_lab_plan = voice_lab_sub.add_parser("plan", help="Build a campaign plan without synthesizing audio")
     _add_voice_lab_args(voice_lab_plan)
     voice_lab_render = voice_lab_sub.add_parser("render", help="Render a best-effort voice campaign")
     _add_voice_lab_args(voice_lab_render, include_out=True)
+    voice_lab_pairwise = voice_lab_sub.add_parser(
+        "pairwise",
+        help="Build a static listening bundle from one rendered campaign",
+    )
+    voice_lab_pairwise.add_argument("campaign", help="Path to campaign.json")
+    voice_lab_pairwise.add_argument("--probe", default="identity-neutral")
+    voice_lab_pairwise.add_argument(
+        "--dimension",
+        choices=tuple(sorted(PAIRWISE_DIMENSIONS)),
+        default="french_pronunciation",
+    )
+    voice_lab_pairwise.add_argument("--rounds", type=int, default=4)
+    voice_lab_pairwise.add_argument("--cross-gender", action="store_true")
+    voice_lab_pairwise.add_argument("--out", default="voice-pairwise")
 
     sounds = sub.add_parser("sounds", help="Publish the validated production sound meta-index")
     sounds.add_argument("--catalog", default=None)
@@ -205,6 +232,15 @@ def main(argv=None):
         elif args.command == "voice-lab":
             if args.voice_lab_command == "catalog":
                 result = probe_catalog()
+            elif args.voice_lab_command == "pairwise":
+                result = write_pairwise_bundle(
+                    args.campaign,
+                    args.out,
+                    probe_id=args.probe,
+                    dimension=args.dimension,
+                    rounds=args.rounds,
+                    same_gender=not args.cross_gender,
+                )
             else:
                 config, _ = load_voice_config(args.voices)
                 if args.voice_lab_command == "plan":
@@ -213,6 +249,7 @@ def main(argv=None):
                         scope=args.scope,
                         stage=args.stage,
                         limit=args.limit,
+                        candidate_set=args.candidate_set,
                     )
                 else:
                     result = render_campaign(
@@ -221,6 +258,7 @@ def main(argv=None):
                         scope=args.scope,
                         stage=args.stage,
                         limit=args.limit,
+                        candidate_set=args.candidate_set,
                     )
         elif args.command == "sounds":
             if args.id:

--- a/src/audio_engine/voice_lab.py
+++ b/src/audio_engine/voice_lab.py
@@ -1,5 +1,6 @@
 import json
 import re
+import shutil
 from pathlib import Path
 
 from .providers.edge import EdgeProvider
@@ -7,6 +8,16 @@ from .voices import load_voice_config
 
 
 AGE_STAGES = ("child", "teen", "young_adult", "adult", "mature", "older", "very_old")
+PROVIDER_CANDIDATE_SETS = ("fr", "fr-plus-multilingual")
+
+PAIRWISE_DIMENSIONS = {
+    "french_pronunciation": "Quelle voix prononce le français de la façon la plus correcte et naturelle ?",
+    "naturalness": "Quelle voix semble la plus naturelle et la moins synthétique ?",
+    "narrative_fit": "Quelle voix donne le plus envie d'écouter la suite de l'histoire ?",
+    "acting_fit": "Quelle voix sert le mieux l'intention dramatique de cette réplique ?",
+    "long_form_fatigue": "Quelle voix paraît la moins fatigante pour une écoute prolongée ?",
+    "lineage_continuity": "Laquelle semble la plus crédible comme autre âge du même personnage de référence ?",
+}
 
 PROBES = (
     {
@@ -131,14 +142,18 @@ PROBES = (
 
 def probe_catalog():
     return {
-        "version": 1,
+        "version": 2,
         "age_stages": list(AGE_STAGES),
+        "provider_candidate_sets": list(PROVIDER_CANDIDATE_SETS),
+        "pairwise_dimensions": PAIRWISE_DIMENSIONS,
         "principles": {
             "identity_first": True,
             "emotion_never_implies_recast": True,
             "age_is_a_lineage_problem": True,
             "runtime_ml_required": False,
             "provider_controls_are_measured_not_assumed": True,
+            "multilingual_french_is_benchmarked_not_assumed": True,
+            "artistic_scores_require_listening_evidence": True,
         },
         "probes": list(PROBES),
     }
@@ -165,22 +180,49 @@ def _preset_candidates(voice_config):
     return result
 
 
-def _provider_candidates(provider, locale_prefix="fr-"):
-    return [
-        {
-            "candidate_id": item["voice"],
+def _provider_candidates(provider, candidate_set="fr"):
+    if candidate_set == "fr":
+        voices = provider.list_voices(locale_prefix="fr-")
+    elif candidate_set == "fr-plus-multilingual":
+        voices = provider.list_voices(locale_prefix=None)
+        voices = [
+            item
+            for item in voices
+            if str(item.get("locale") or "").startswith("fr-")
+            or "multilingual" in str(item.get("voice") or "").lower()
+        ]
+    else:
+        raise ValueError(
+            "candidate_set must be one of: " + ", ".join(PROVIDER_CANDIDATE_SETS)
+        )
+
+    result = []
+    seen = set()
+    for item in voices:
+        voice = item.get("voice")
+        if not voice or voice in seen:
+            continue
+        seen.add(voice)
+        result.append({
+            "candidate_id": voice,
             "source": "provider-voice",
-            "voice": item["voice"],
+            "voice": voice,
             "rate": "+0%",
             "pitch": "+0Hz",
             "volume": "+0%",
             "provider_metadata": item,
-        }
-        for item in provider.list_voices(locale_prefix=locale_prefix)
-    ]
+        })
+    return result
 
 
-def build_campaign(voice_config=None, provider=None, scope="presets", stage="fingerprint", limit=None):
+def build_campaign(
+    voice_config=None,
+    provider=None,
+    scope="presets",
+    stage="fingerprint",
+    limit=None,
+    candidate_set="fr",
+):
     if stage not in {"fingerprint", "expressive", "age", "long-form", "all"}:
         raise ValueError("stage must be fingerprint, expressive, age, long-form, or all")
     provider = provider or EdgeProvider()
@@ -190,7 +232,7 @@ def build_campaign(voice_config=None, provider=None, scope="presets", stage="fin
     if scope == "presets":
         candidates = _preset_candidates(voice_config)
     elif scope == "provider":
-        candidates = _provider_candidates(provider)
+        candidates = _provider_candidates(provider, candidate_set=candidate_set)
     else:
         raise ValueError("scope must be presets or provider")
 
@@ -210,9 +252,10 @@ def build_campaign(voice_config=None, provider=None, scope="presets", stage="fin
             break
 
     return {
-        "version": 1,
+        "version": 2,
         "scope": scope,
         "stage": stage,
+        "candidate_set": candidate_set if scope == "provider" else None,
         "provider": provider.name,
         "provider_processing": provider.processing,
         "provider_expressive_controls": list(getattr(provider, "expressive_controls", ())),
@@ -236,7 +279,15 @@ def build_campaign(voice_config=None, provider=None, scope="presets", stage="fin
     }
 
 
-def render_campaign(output_dir, voice_config=None, provider=None, scope="presets", stage="fingerprint", limit=None):
+def render_campaign(
+    output_dir,
+    voice_config=None,
+    provider=None,
+    scope="presets",
+    stage="fingerprint",
+    limit=None,
+    candidate_set="fr",
+):
     provider = provider or EdgeProvider()
     plan = build_campaign(
         voice_config=voice_config,
@@ -244,6 +295,7 @@ def render_campaign(output_dir, voice_config=None, provider=None, scope="presets
         scope=scope,
         stage=stage,
         limit=limit,
+        candidate_set=candidate_set,
     )
     output_dir = Path(output_dir)
     clips_dir = output_dir / "clips"
@@ -281,3 +333,214 @@ def render_campaign(output_dir, voice_config=None, provider=None, scope="presets
         encoding="utf-8",
     )
     return result
+
+
+def _candidate_map(campaign):
+    candidates = {}
+    for job in campaign.get("jobs", []):
+        candidate = job.get("candidate") or {}
+        candidate_id = candidate.get("candidate_id")
+        if candidate_id:
+            candidates[candidate_id] = candidate
+    return candidates
+
+
+def _rendered_map(campaign):
+    return {
+        item.get("job_id"): item.get("file")
+        for item in campaign.get("rendered", [])
+        if item.get("job_id") and item.get("file")
+    }
+
+
+def _round_robin_pairs(items, rounds):
+    items = list(items)
+    if len(items) < 2 or rounds <= 0:
+        return []
+    if len(items) % 2:
+        items.append(None)
+    count = len(items)
+    maximum_rounds = count - 1
+    rounds = min(rounds, maximum_rounds)
+    rotation = list(items)
+    result = []
+    for round_index in range(rounds):
+        pairs = []
+        for index in range(count // 2):
+            left = rotation[index]
+            right = rotation[count - 1 - index]
+            if left is None or right is None:
+                continue
+            if (round_index + index) % 2:
+                left, right = right, left
+            pairs.append((left, right, round_index + 1))
+        result.extend(pairs)
+        rotation = [rotation[0], rotation[-1], *rotation[1:-1]]
+    return result
+
+
+def build_pairwise_plan(
+    campaign,
+    probe_id="identity-neutral",
+    dimension="french_pronunciation",
+    rounds=4,
+    same_gender=True,
+):
+    if dimension not in PAIRWISE_DIMENSIONS:
+        raise ValueError(
+            "dimension must be one of: " + ", ".join(sorted(PAIRWISE_DIMENSIONS))
+        )
+    candidates = _candidate_map(campaign)
+    rendered = _rendered_map(campaign)
+    available = []
+    for candidate_id, candidate in sorted(candidates.items()):
+        job_id = f"{_slug(candidate_id)}--{probe_id}"
+        if job_id in rendered:
+            available.append(candidate_id)
+    if len(available) < 2:
+        raise ValueError(f"campaign has fewer than two rendered candidates for probe {probe_id}")
+
+    groups = {}
+    for candidate_id in available:
+        candidate = candidates[candidate_id]
+        gender = (candidate.get("provider_metadata") or {}).get("gender")
+        if not gender:
+            gender = (candidate.get("traits") or {}).get("gender")
+        group = gender if same_gender and gender else "all"
+        groups.setdefault(group, []).append(candidate_id)
+
+    comparisons = []
+    for group, candidate_ids in sorted(groups.items()):
+        for left_id, right_id, round_index in _round_robin_pairs(candidate_ids, rounds):
+            left_job = f"{_slug(left_id)}--{probe_id}"
+            right_job = f"{_slug(right_id)}--{probe_id}"
+            comparisons.append({
+                "id": f"{_slug(dimension)}--{_slug(probe_id)}--{len(comparisons)+1:03d}",
+                "dimension": dimension,
+                "question": PAIRWISE_DIMENSIONS[dimension],
+                "probe_id": probe_id,
+                "group": group,
+                "round": round_index,
+                "left": {
+                    "candidate_id": left_id,
+                    "voice": candidates[left_id].get("voice"),
+                    "file": rendered[left_job],
+                },
+                "right": {
+                    "candidate_id": right_id,
+                    "voice": candidates[right_id].get("voice"),
+                    "file": rendered[right_job],
+                },
+            })
+
+    return {
+        "version": 1,
+        "kind": "pairwise",
+        "dimension": dimension,
+        "question": PAIRWISE_DIMENSIONS[dimension],
+        "probe_id": probe_id,
+        "same_gender": bool(same_gender),
+        "rounds_requested": rounds,
+        "candidate_count": len(available),
+        "comparison_count": len(comparisons),
+        "comparisons": comparisons,
+        "result_contract": {
+            "decision_values": ["left", "right", "tie", "reject-both"],
+            "note": "Listening evidence is required. The plan contains no pre-decided artistic winner.",
+        },
+    }
+
+
+def _pairwise_html(plan):
+    data = json.dumps(plan, ensure_ascii=False).replace("</", "<\\/")
+    return f"""<!doctype html>
+<html lang=\"fr\">
+<meta charset=\"utf-8\">
+<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">
+<title>Voice Casting Pairwise</title>
+<style>
+body{{font-family:system-ui,sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem;line-height:1.45}}
+.card{{border:1px solid #ccc;border-radius:12px;padding:1rem;margin:1rem 0}}
+.row{{display:grid;grid-template-columns:1fr 1fr;gap:1rem}}
+button{{padding:.7rem 1rem;margin:.25rem;cursor:pointer}}
+audio{{width:100%}}
+.small{{opacity:.7;font-size:.9rem}}
+@media(max-width:640px){{.row{{grid-template-columns:1fr}}}}
+</style>
+<h1>Voice Casting — comparaison pairwise</h1>
+<p id=\"summary\"></p>
+<div id=\"app\"></div>
+<button id=\"export\">Exporter les décisions JSON</button>
+<script>
+const plan={data};
+const decisions={{}};
+let index=0;
+const app=document.getElementById('app');
+const summary=document.getElementById('summary');
+function render(){{
+ const c=plan.comparisons[index];
+ summary.textContent=`${{plan.dimension}} — ${{index+1}}/${{plan.comparisons.length}}`;
+ if(!c){{app.innerHTML='<p>Évaluation terminée. Exportez les décisions.</p>';return;}}
+ app.innerHTML=`<div class=\"card\"><h2>${{c.question}}</h2><p class=\"small\">Probe: ${{c.probe_id}} · groupe: ${{c.group}}</p><div class=\"row\"><div><strong>A</strong><audio controls preload=\"none\" src=\"${{c.left.file}}\"></audio></div><div><strong>B</strong><audio controls preload=\"none\" src=\"${{c.right.file}}\"></audio></div></div><p><button data-v=\"left\">A gagne</button><button data-v=\"right\">B gagne</button><button data-v=\"tie\">Égalité</button><button data-v=\"reject-both\">Rejeter les deux</button></p></div>`;
+ app.querySelectorAll('button[data-v]').forEach(b=>b.onclick=()=>{{decisions[c.id]=b.dataset.v;index++;render();}});
+}}
+document.getElementById('export').onclick=()=>{{
+ const result={{version:1,kind:'pairwise-results',dimension:plan.dimension,probe_id:plan.probe_id,decisions}};
+ const blob=new Blob([JSON.stringify(result,null,2)],{{type:'application/json'}});
+ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='pairwise-results.json';a.click();URL.revokeObjectURL(a.href);
+}};
+render();
+</script>
+</html>"""
+
+
+def write_pairwise_bundle(
+    campaign_path,
+    output_dir,
+    probe_id="identity-neutral",
+    dimension="french_pronunciation",
+    rounds=4,
+    same_gender=True,
+):
+    campaign_path = Path(campaign_path)
+    campaign = json.loads(campaign_path.read_text(encoding="utf-8"))
+    plan = build_pairwise_plan(
+        campaign,
+        probe_id=probe_id,
+        dimension=dimension,
+        rounds=rounds,
+        same_gender=same_gender,
+    )
+    output_dir = Path(output_dir)
+    clips_dir = output_dir / "clips"
+    clips_dir.mkdir(parents=True, exist_ok=True)
+    source_root = campaign_path.parent
+
+    copied = {}
+    for comparison in plan["comparisons"]:
+        for side in ("left", "right"):
+            relative = comparison[side]["file"]
+            source = source_root / relative
+            if not source.exists():
+                raise FileNotFoundError(f"missing campaign clip: {source}")
+            filename = Path(relative).name
+            destination = clips_dir / filename
+            if filename not in copied:
+                shutil.copyfile(source, destination)
+                copied[filename] = True
+            comparison[side]["file"] = f"clips/{filename}"
+
+    (output_dir / "pairwise-plan.json").write_text(
+        json.dumps(plan, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (output_dir / "index.html").write_text(_pairwise_html(plan), encoding="utf-8")
+    return {
+        "status": "success",
+        "output": str(output_dir),
+        "candidate_count": plan["candidate_count"],
+        "comparison_count": plan["comparison_count"],
+        "copied_clip_count": len(copied),
+        "plan": "pairwise-plan.json",
+        "player": "index.html",
+    }

--- a/tests/test_voice_lab.py
+++ b/tests/test_voice_lab.py
@@ -1,8 +1,16 @@
+import json
 import tempfile
 import unittest
 from pathlib import Path
 
-from audio_engine.voice_lab import AGE_STAGES, build_campaign, probe_catalog, render_campaign
+from audio_engine.voice_lab import (
+    AGE_STAGES,
+    build_campaign,
+    build_pairwise_plan,
+    probe_catalog,
+    render_campaign,
+    write_pairwise_bundle,
+)
 from audio_engine.voices import resolve_segments
 
 
@@ -48,7 +56,14 @@ class FakeProvider:
     def list_voices(self, locale_prefix=None):
         voices = [
             {"voice": "fr-FR-OneNeural", "locale": "fr-FR", "gender": "female", "friendly_name": "One"},
-            {"voice": "en-US-TwoNeural", "locale": "en-US", "gender": "male", "friendly_name": "Two"},
+            {"voice": "fr-FR-ThreeNeural", "locale": "fr-FR", "gender": "female", "friendly_name": "Three"},
+            {
+                "voice": "en-US-TwoMultilingualNeural",
+                "locale": "en-US",
+                "gender": "male",
+                "friendly_name": "Two multilingual",
+            },
+            {"voice": "en-US-PlainNeural", "locale": "en-US", "gender": "male", "friendly_name": "Plain"},
         ]
         if locale_prefix:
             voices = [item for item in voices if item["locale"].startswith(locale_prefix)]
@@ -63,6 +78,7 @@ class VoiceLabTests(unittest.TestCase):
         catalog = probe_catalog()
         self.assertTrue(catalog["principles"]["identity_first"])
         self.assertTrue(catalog["principles"]["emotion_never_implies_recast"])
+        self.assertTrue(catalog["principles"]["multilingual_french_is_benchmarked_not_assumed"])
         self.assertEqual(tuple(catalog["age_stages"]), AGE_STAGES)
         self.assertTrue(any(item["kind"] == "age-lineage" for item in catalog["probes"]))
         self.assertTrue(any(item["kind"] == "performance" for item in catalog["probes"]))
@@ -74,11 +90,26 @@ class VoiceLabTests(unittest.TestCase):
             scope="provider",
             stage="fingerprint",
         )
-        self.assertEqual(plan["candidate_count"], 1)
+        self.assertEqual(plan["candidate_count"], 2)
         self.assertEqual(plan["probe_count"], 3)
-        self.assertEqual(plan["job_count"], 3)
+        self.assertEqual(plan["job_count"], 6)
         self.assertEqual(plan["jobs"][0]["candidate"]["voice"], "fr-FR-OneNeural")
         self.assertNotIn("traits", plan["jobs"][0]["candidate"])
+
+    def test_provider_candidate_set_adds_multilingual_without_all_foreign_voices(self):
+        plan = build_campaign(
+            voice_config=VOICE_CONFIG,
+            provider=FakeProvider(),
+            scope="provider",
+            stage="age",
+            candidate_set="fr-plus-multilingual",
+        )
+        voices = {job["candidate"]["voice"] for job in plan["jobs"]}
+        self.assertEqual(
+            voices,
+            {"fr-FR-OneNeural", "fr-FR-ThreeNeural", "en-US-TwoMultilingualNeural"},
+        )
+        self.assertNotIn("en-US-PlainNeural", voices)
 
     def test_render_campaign_is_best_effort_and_persists_manifest(self):
         with tempfile.TemporaryDirectory() as temp_value:
@@ -97,6 +128,58 @@ class VoiceLabTests(unittest.TestCase):
                 len(list((root / "clips").glob("*.mp3"))),
                 len(VOICE_CONFIG["presets"]),
             )
+
+    def test_pairwise_plan_is_balanced_and_does_not_invent_winners(self):
+        campaign = {
+            "jobs": [],
+            "rendered": [],
+        }
+        for voice in ("a", "b", "c", "d"):
+            candidate = {
+                "candidate_id": voice,
+                "voice": voice,
+                "provider_metadata": {"gender": "female"},
+            }
+            job_id = f"{voice}--identity-neutral"
+            campaign["jobs"].append(
+                {"id": job_id, "candidate": candidate, "probe": {"id": "identity-neutral"}}
+            )
+            campaign["rendered"].append({"job_id": job_id, "file": f"clips/{job_id}.mp3"})
+        plan = build_pairwise_plan(campaign, rounds=2)
+        self.assertEqual(plan["candidate_count"], 4)
+        self.assertEqual(plan["comparison_count"], 4)
+        self.assertNotIn("winner", json.dumps(plan))
+        participation = {voice: 0 for voice in ("a", "b", "c", "d")}
+        for comparison in plan["comparisons"]:
+            participation[comparison["left"]["candidate_id"]] += 1
+            participation[comparison["right"]["candidate_id"]] += 1
+        self.assertEqual(set(participation.values()), {2})
+
+    def test_pairwise_bundle_copies_only_needed_clips_and_writes_player(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            root = Path(temp_value)
+            campaign_dir = root / "campaign"
+            clips = campaign_dir / "clips"
+            clips.mkdir(parents=True)
+            rendered = render_campaign(
+                campaign_dir,
+                voice_config=VOICE_CONFIG,
+                provider=FakeProvider(),
+                scope="provider",
+                stage="fingerprint",
+            )
+            self.assertEqual(rendered["rendered_count"], 6)
+            out = root / "pairwise"
+            result = write_pairwise_bundle(
+                campaign_dir / "campaign.json",
+                out,
+                rounds=1,
+            )
+            self.assertEqual(result["status"], "success")
+            self.assertTrue((out / "pairwise-plan.json").exists())
+            self.assertTrue((out / "index.html").exists())
+            self.assertEqual(result["comparison_count"], 1)
+            self.assertEqual(result["copied_clip_count"], 2)
 
     def test_character_target_changes_do_not_recast_identity(self):
         program = {

--- a/tests/test_voice_lab.py
+++ b/tests/test_voice_lab.py
@@ -148,7 +148,9 @@ class VoiceLabTests(unittest.TestCase):
         plan = build_pairwise_plan(campaign, rounds=2)
         self.assertEqual(plan["candidate_count"], 4)
         self.assertEqual(plan["comparison_count"], 4)
-        self.assertNotIn("winner", json.dumps(plan))
+        self.assertNotIn("winner", plan)
+        for comparison in plan["comparisons"]:
+            self.assertNotIn("winner", comparison)
         participation = {voice: 0 for voice in ("a", "b", "c", "d")}
         for comparison in plan["comparisons"]:
             participation[comparison["left"]["candidate_id"]] += 1


### PR DESCRIPTION
## Why
The first real campaign proved the lab works but exposed two gaps: the provider scan only covered `fr-*` locales, and listening judgments still lived outside a reproducible evaluation contract.

## What changes
- adds provider candidate sets: conservative `fr` and `fr-plus-multilingual`
- includes provider voices named `Multilingual*` in the expanded research set without assuming their French is acceptable
- keeps French pronunciation eliminatory before any promotion
- adds deterministic sparse round-robin pairwise plans, stratified by provider gender by default
- adds a dependency-free static HTML listener that exports explicit JSON decisions
- copies only clips required by the comparison plan
- extends the manual GitHub Actions campaign workflow with the candidate-set selector
- documents that acoustic pre-screening is not an artistic score

## Non-goals
- no automatic artistic winner
- no automatic promotion of multilingual voices
- no ML/runtime dependency
- no claim that an age-anchor alone validates a voice lineage

## Next experiment after merge
Run a fingerprint campaign over `fr-plus-multilingual`, apply the French quality gate, then only expand surviving voices to expressive/age/long-form tests.