### PR TITLE
Edge: decouple multilingual voice identity from speech locale

### DIFF
--- a/src/audio_engine/providers/edge.py
+++ b/src/audio_engine/providers/edge.py
@@ -10,6 +10,17 @@ def _locale_from_voice(voice):
     return match.group(1) if match else None
 
 
+def _speech_locale(communicate):
+    """Resolve the SSML language independently from the provider voice identity.
+
+    Normal voices keep their provider locale. Multilingual laboratory calls may
+    attach `_audio_engine_language_locale` to request French while deliberately
+    retaining a voice whose native provider locale is different.
+    """
+    explicit = getattr(communicate, "_audio_engine_language_locale", None)
+    return explicit or _locale_from_voice(getattr(communicate, "voice", None))
+
+
 def patch_ssml_locale():
     global _PATCHED
     if _PATCHED:
@@ -20,7 +31,7 @@ def patch_ssml_locale():
         if original:
             def localized(communicate, escaped_text):
                 ssml = original(communicate, escaped_text)
-                locale = _locale_from_voice(getattr(communicate, "voice", None))
+                locale = _speech_locale(communicate)
                 if locale:
                     ssml = re.sub(
                         r"xml:lang=(['\"])en-US\1",
@@ -72,6 +83,9 @@ class EdgeProvider:
                     pitch=segment.get("pitch", "+0Hz"),
                     volume=segment.get("volume", "+0%"),
                 )
+                language_locale = segment.get("language_locale")
+                if language_locale:
+                    communicator._audio_engine_language_locale = language_locale
                 await communicator.save(str(path))
                 return
             except Exception as exc:

--- a/tests/test_edge_locale.py
+++ b/tests/test_edge_locale.py
@@ -1,0 +1,55 @@
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from audio_engine.providers.edge import EdgeProvider, _speech_locale
+
+
+class EdgeLocaleTests(unittest.TestCase):
+    def test_native_voice_uses_its_provider_locale(self):
+        communicate = SimpleNamespace(voice="fr-FR-DeniseNeural")
+        self.assertEqual(_speech_locale(communicate), "fr-FR")
+
+    def test_explicit_language_locale_overrides_multilingual_voice_locale(self):
+        communicate = SimpleNamespace(
+            voice="en-US-AvaMultilingualNeural",
+            _audio_engine_language_locale="fr-FR",
+        )
+        self.assertEqual(_speech_locale(communicate), "fr-FR")
+
+    def test_provider_attaches_explicit_language_locale_before_save(self):
+        captured = {}
+
+        class FakeCommunicate:
+            def __init__(self, text, voice, rate, pitch, volume):
+                self.text = text
+                self.voice = voice
+                captured["instance"] = self
+
+            async def save(self, path):
+                Path(path).write_bytes(b"fake")
+
+        with tempfile.TemporaryDirectory() as temp_value:
+            output = Path(temp_value) / "voice.mp3"
+            with patch("audio_engine.providers.edge.edge_tts.Communicate", FakeCommunicate):
+                provider = EdgeProvider()
+                asyncio.run(provider.synthesize_async({
+                    "text": "Bonjour.",
+                    "voice": "en-US-AvaMultilingualNeural",
+                    "rate": "+0%",
+                    "pitch": "+0Hz",
+                    "volume": "+0%",
+                    "language_locale": "fr-FR",
+                }, output))
+            self.assertTrue(output.exists())
+            self.assertEqual(
+                captured["instance"]._audio_engine_language_locale,
+                "fr-FR",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
The expanded Voice Casting Lab exposed a real multilingual edge case: Audio Engine patched SSML language from the provider voice locale. That is correct for native `fr-*` voices, but it can force `en-US`, `it-IT`, etc. when intentionally testing a MultilingualNeural voice in French.

## What changes
- adds an explicit internal `language_locale` synthesis override
- SSML language now resolves independently from provider voice identity
- native behavior is unchanged when no override is supplied
- adds offline tests proving `en-US-AvaMultilingualNeural` can be requested with `fr-FR` speech locale

## Scope
This is provider plumbing only. Production contracts do not automatically expose or change language locale; the Voice Casting Lab can use the override explicitly for cross-locale multilingual experiments.