### PR TITLE
Voice Lab: add isolated Chatterbox V3 killer test

### DIFF
--- a/.github/workflows/voice-casting-chatterbox-killer.yml
+++ b/.github/workflows/voice-casting-chatterbox-killer.yml
@@ -1,0 +1,86 @@
+name: Voice Casting Chatterbox V3 Killer Test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/voice-casting-chatterbox-killer.yml
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  chatterbox-killer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      HF_HOME: ${{ github.workspace }}/.hf-cache
+      TOKENIZERS_PARALLELISM: "false"
+      OMP_NUM_THREADS: "2"
+      MKL_NUM_THREADS: "2"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Cache public Chatterbox model files
+        uses: actions/cache@v4
+        with:
+          path: .hf-cache
+          key: chatterbox-multilingual-v3-20260824
+
+      - name: Install core engine
+        run: python -m pip install --disable-pip-version-check -e .
+
+      - name: Verify isolated experiment contract
+        run: python -m unittest tests.test_voice_lab_chatterbox_killer -v
+
+      - name: Install optional Chatterbox lab environment
+        run: |
+          python -m pip install --disable-pip-version-check chatterbox-tts==0.1.7
+          python -m pip check
+          df -h .
+
+      - name: Render 2-case CPU killer test
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from audio_engine.voice_lab_chatterbox_killer import render_experiment
+
+          result = render_experiment(Path("chatterbox-killer-output"))
+          print(json.dumps({
+              "status": result["status"],
+              "rendered_count": result["rendered_count"],
+              "failure_count": result["failure_count"],
+              "case_count": len(result["cases"]),
+          }, indent=2))
+          if result["status"] != "success":
+              print(json.dumps(result["failures"], indent=2, ensure_ascii=False))
+              raise SystemExit(1)
+          PY
+
+      - name: Upload blind listening bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: voice-casting-chatterbox-v3-killer
+          path: chatterbox-killer-output/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Publish run locator
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Voice Casting Chatterbox V3 killer $RUN_ID" \
+            --body "Open/local Chatterbox Multilingual V3 killer test completed.\n\n- run_id: $RUN_ID\n- run: $RUN_URL\n- artifact: voice-casting-chatterbox-v3-killer\n- reference identity: synthetic Edge Vivienne, French\n- cases: panic + mystery\n- design: Edge baseline vs Chatterbox neutral/dramatic/strong\n- 8 comparison clips / 2 blind decisions\n\nLab evidence only. No production dependency or provider promotion."

--- a/docs/VOICE_CASTING_OPEN_MODELS.md
+++ b/docs/VOICE_CASTING_OPEN_MODELS.md
@@ -1,0 +1,45 @@
+# Open/local expressive TTS challengers
+
+Status: Voice Casting Lab research only.
+
+## Arbitration — 2026-08-24
+
+The current Edge path remains the production reference because it is simple, reliable and already validated for narration/identity. Human listening showed that rate/pitch/volume alone does not reliably produce acting on hard intentions, so open/local expressive models are evaluated as challengers.
+
+### 1. Chatterbox Multilingual V3 — first killer test
+
+Why first:
+
+- MIT code/model distribution;
+- current multilingual V3 explicitly supports French;
+- 0.5B multilingual T3 family;
+- zero-shot voice cloning from a reference clip;
+- local CPU path exists, although GPU is preferable;
+- simpler experimental integration than CosyVoice;
+- no cloud credentials or per-character pricing.
+
+Important limitation: `exaggeration` is an intensity-style scalar, not a semantic acting instruction such as fear, restrained anger or mystery. Earlier multilingual Chatterbox versions also had community reports that exaggeration produced little perceptual effect. V3 claims improved expressive generation, so this must be measured rather than assumed.
+
+The first experiment is intentionally tiny: one synthetic French reference identity (Edge Vivienne), two hard intentions (panic and mystery), and four blind options per intention: Edge baseline plus three Chatterbox V3 configurations. Chatterbox remains an optional lab dependency and is not added to `pyproject.toml`.
+
+### 2. CosyVoice 3 — semantic challenger if needed
+
+CosyVoice 3 remains the strongest next candidate when semantic instruction following is required. The public 0.5B model is Apache-2.0 and the family supports multilingual / zero-shot / instruction-oriented inference. It is not first because its installation/deployment surface is significantly heavier (repository/submodules, normalization/runtime tooling and a larger operational envelope).
+
+### 3. Parler-TTS Multilingual — descriptive-style challenger
+
+Parler-TTS Multilingual remains useful because speaking style is described in natural language and the model/code are permissively licensed. The current multilingual mini checkpoint is ~0.9B / ~3.75 GB and older than the other two candidates, so it is a second-line research option rather than the first integration.
+
+## Governance
+
+No open model is promoted by benchmark generation alone. Promotion requires human listening evidence for:
+
+1. French pronunciation;
+2. naturalness;
+3. identity continuity;
+4. acting fit on difficult intentions;
+5. long-form fatigue;
+6. operational simplicity/reliability;
+7. reproducible provenance and graceful fallback.
+
+Heavy ML dependencies stay outside the production Audio Engine dependency graph unless a later promotion decision explicitly changes that boundary.

--- a/src/audio_engine/providers/chatterbox_lab.py
+++ b/src/audio_engine/providers/chatterbox_lab.py
@@ -1,0 +1,62 @@
+"""Optional Chatterbox provider for Voice Casting Lab experiments only.
+
+This module intentionally imports Chatterbox/Torch lazily so the production
+Audio Engine runtime keeps its small dependency surface. It is not wired into
+public render contracts or production provider selection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class ChatterboxLabProvider:
+    name = "chatterbox-v3-lab"
+    processing = "local-optional"
+    expressive_controls = ("exaggeration", "cfg_weight", "temperature", "seed")
+
+    def __init__(self, *, device: str = "cpu", t3_model: str = "v3"):
+        try:
+            import torch
+            import torchaudio
+            from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+        except ImportError as exc:
+            raise RuntimeError(
+                "Chatterbox lab provider requires the optional 'chatterbox-tts' "
+                "environment; it is intentionally not an audio-engine dependency."
+            ) from exc
+
+        self._torch = torch
+        self._torchaudio = torchaudio
+        self.device = device
+        self.t3_model = t3_model
+        if device == "cpu":
+            try:
+                torch.set_num_threads(2)
+            except Exception:
+                pass
+        self.model = ChatterboxMultilingualTTS.from_pretrained(
+            device=device,
+            t3_model=t3_model,
+        )
+
+    def synthesize(self, segment: dict, path) -> None:
+        audio_prompt_path = segment.get("audio_prompt_path")
+        if not audio_prompt_path:
+            raise ValueError("Chatterbox lab synthesis requires audio_prompt_path")
+        prompt = Path(audio_prompt_path)
+        if not prompt.exists():
+            raise FileNotFoundError(prompt)
+
+        seed = int(segment.get("seed", 20260824))
+        self._torch.manual_seed(seed)
+
+        wav = self.model.generate(
+            str(segment["text"]),
+            language_id=str(segment.get("language_id", "fr")),
+            audio_prompt_path=str(prompt),
+            exaggeration=float(segment.get("exaggeration", 0.5)),
+            cfg_weight=float(segment.get("cfg_weight", 0.5)),
+            temperature=float(segment.get("temperature", 0.8)),
+        )
+        self._torchaudio.save(str(path), wav, self.model.sr)

--- a/src/audio_engine/voice_lab_chatterbox_killer.py
+++ b/src/audio_engine/voice_lab_chatterbox_killer.py
@@ -1,0 +1,244 @@
+"""Minimal blind killer test for Chatterbox Multilingual V3.
+
+The purpose is to decide whether the fully open/local model deserves a larger
+benchmark before we spend more compute or add semantic-instruction models.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import subprocess
+from pathlib import Path
+
+from imageio_ffmpeg import get_ffmpeg_exe
+
+from .providers.chatterbox_lab import ChatterboxLabProvider
+from .providers.edge import EdgeProvider
+
+
+REFERENCE_VOICE = "fr-FR-VivienneMultilingualNeural"
+REFERENCE_TEXT = (
+    "À l'aube, personne dans la ville ne savait encore ce qui allait se produire. "
+    "Approchez. Ce que je vais vous dire ne doit sortir d'ici sous aucun prétexte."
+)
+
+CASES = (
+    {
+        "id": "panic",
+        "intention": "panique",
+        "text": "Vite ! Ils arrivent ! Fermez la porte !",
+    },
+    {
+        "id": "mystery",
+        "intention": "mystère",
+        "text": "Depuis trois nuits, la même lumière apparaît derrière cette fenêtre condamnée.",
+    },
+)
+
+TREATMENTS = (
+    {
+        "id": "edge-baseline",
+        "provider": "edge",
+    },
+    {
+        "id": "chatterbox-neutral",
+        "provider": "chatterbox",
+        "exaggeration": 0.5,
+        "cfg_weight": 0.5,
+    },
+    {
+        "id": "chatterbox-dramatic",
+        "provider": "chatterbox",
+        "exaggeration": 0.8,
+        "cfg_weight": 0.3,
+    },
+    {
+        "id": "chatterbox-strong",
+        "provider": "chatterbox",
+        "exaggeration": 1.2,
+        "cfg_weight": 0.3,
+    },
+)
+
+
+def experiment_spec():
+    return {
+        "version": 1,
+        "kind": "chatterbox-v3-killer-test",
+        "production_promotion": False,
+        "reference": {
+            "voice": REFERENCE_VOICE,
+            "text": REFERENCE_TEXT,
+            "source": "synthetic-edge-reference",
+        },
+        "model": {
+            "family": "Chatterbox Multilingual",
+            "t3_model": "v3",
+            "language_id": "fr",
+            "optional_dependency": True,
+        },
+        "cases": [
+            {**case, "treatments": [dict(item) for item in TREATMENTS]}
+            for case in CASES
+        ],
+        "decision": {
+            "promising_if": (
+                "Chatterbox produces at least one artistically acceptable winner "
+                "over Edge while preserving French pronunciation and recognizable identity."
+            ),
+            "next_if_promising": "expand to two voices and four hard intentions",
+            "next_if_not_promising": "skip directly to semantic-instruction challenger",
+        },
+    }
+
+
+def _convert_reference(mp3_path: Path, wav_path: Path) -> None:
+    subprocess.run(
+        [
+            get_ffmpeg_exe(),
+            "-y",
+            "-i",
+            str(mp3_path),
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            str(wav_path),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def render_experiment(output_dir, *, edge=None, chatterbox=None):
+    output_dir = Path(output_dir)
+    clips_dir = output_dir / "clips"
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    edge = edge or EdgeProvider()
+    reference_mp3 = output_dir / "reference-edge.mp3"
+    reference_wav = output_dir / "reference-edge-16k.wav"
+    edge.synthesize(
+        {
+            "text": REFERENCE_TEXT,
+            "voice": REFERENCE_VOICE,
+            "rate": "+0%",
+            "pitch": "+0Hz",
+            "volume": "+0%",
+            "language_locale": "fr-FR",
+        },
+        reference_mp3,
+    )
+    _convert_reference(reference_mp3, reference_wav)
+
+    chatterbox = chatterbox or ChatterboxLabProvider(device="cpu", t3_model="v3")
+    spec = experiment_spec()
+    rendered = []
+    failures = []
+
+    for case in spec["cases"]:
+        for treatment in case["treatments"]:
+            filename = f"{case['id']}--{treatment['id']}.wav"
+            path = clips_dir / filename
+            try:
+                if treatment["provider"] == "edge":
+                    mp3_path = clips_dir / f"{case['id']}--edge-baseline.mp3"
+                    edge.synthesize(
+                        {
+                            "text": case["text"],
+                            "voice": REFERENCE_VOICE,
+                            "rate": "+0%",
+                            "pitch": "+0Hz",
+                            "volume": "+0%",
+                            "language_locale": "fr-FR",
+                        },
+                        mp3_path,
+                    )
+                    _convert_reference(mp3_path, path)
+                    mp3_path.unlink(missing_ok=True)
+                else:
+                    chatterbox.synthesize(
+                        {
+                            "text": case["text"],
+                            "audio_prompt_path": str(reference_wav),
+                            "language_id": "fr",
+                            "exaggeration": treatment["exaggeration"],
+                            "cfg_weight": treatment["cfg_weight"],
+                            "temperature": 0.8,
+                            "seed": 20260824,
+                        },
+                        path,
+                    )
+                rendered.append(
+                    {
+                        "case_id": case["id"],
+                        "treatment_id": treatment["id"],
+                        "file": f"clips/{filename}",
+                    }
+                )
+            except Exception as exc:
+                failures.append(
+                    {
+                        "case_id": case["id"],
+                        "treatment_id": treatment["id"],
+                        "error": str(exc),
+                    }
+                )
+
+    result = {
+        **spec,
+        "status": "success" if not failures else ("partial" if rendered else "failed"),
+        "rendered_count": len(rendered),
+        "failure_count": len(failures),
+        "rendered": rendered,
+        "failures": failures,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    write_blind_player(result, output_dir)
+    return result
+
+
+def write_blind_player(manifest, output_dir, *, seed=20260824):
+    output_dir = Path(output_dir)
+    rendered = {
+        (item["case_id"], item["treatment_id"]): item["file"]
+        for item in manifest.get("rendered", [])
+    }
+    randomizer = random.Random(seed)
+    trials = []
+    for case in manifest["cases"]:
+        options = []
+        for treatment in case["treatments"]:
+            file = rendered.get((case["id"], treatment["id"]))
+            if file:
+                options.append({**treatment, "file": file})
+        if len(options) != len(case["treatments"]):
+            continue
+        randomizer.shuffle(options)
+        trials.append(
+            {
+                "id": case["id"],
+                "intention": case["intention"],
+                "text": case["text"],
+                "options": [
+                    {"letter": letter, **option}
+                    for letter, option in zip("ABCD", options)
+                ],
+            }
+        )
+
+    payload = json.dumps({"version": 1, "trials": trials}, ensure_ascii=False).replace("</", "<\\/")
+    html = f"""<!doctype html><html lang='fr'><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>
+<title>Chatterbox V3 — killer test</title>
+<style>body{{font-family:system-ui,sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem;line-height:1.45}}.card{{border:1px solid #888;border-radius:12px;padding:1rem;margin:1rem 0}}.grid{{display:grid;grid-template-columns:1fr 1fr;gap:1rem}}audio{{width:100%}}button{{padding:.7rem 1rem;margin:.25rem}}@media(max-width:650px){{.grid{{grid-template-columns:1fr}}}}</style>
+<h1>Chatterbox V3 — killer test</h1><p>Deux décisions seulement. Choisis la variante qui joue le mieux l'intention tout en restant naturelle et correctement française.</p>
+<p id='progress'></p><div id='app'></div><button id='export'>Exporter les résultats JSON</button>
+<script>const data={payload};let i=0;const answers={{}};const app=document.getElementById('app');const progress=document.getElementById('progress');
+function render(){{const t=data.trials[i];progress.textContent=t?`Cas ${{i+1}} / ${{data.trials.length}} · ${{t.intention}}`:'Test terminé';if(!t){{app.innerHTML='<p>Exportez les résultats.</p>';return;}}const players=t.options.map(o=>`<div><h3>${{o.letter}}</h3><audio controls preload='none' src='${{o.file}}'></audio></div>`).join('');const buttons=t.options.map(o=>`<button data-v='${{o.letter}}'>${{o.letter}} est meilleure</button>`).join('');app.innerHTML=`<div class='card'><h2>${{t.intention}}</h2><p><em>${{t.text}}</em></p><div class='grid'>${{players}}</div><p>${{buttons}}<button data-v='none'>Aucune acceptable</button><button data-v='invalid-pronunciation'>Prononciation invalide</button></p></div>`;app.querySelectorAll('button[data-v]').forEach(b=>b.onclick=()=>{{answers[t.id]=b.dataset.v;i++;render();}});}}
+document.getElementById('export').onclick=()=>{{const result={{schema:'voice-casting-chatterbox-killer-v1',exported_at:new Date().toISOString(),responses:answers,mapping:data.trials}};const blob=new Blob([JSON.stringify(result,null,2)],{{type:'application/json'}});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='voice-casting-chatterbox-killer-results.json';a.click();setTimeout(()=>URL.revokeObjectURL(a.href),1000);}};render();</script></html>"""
+    (output_dir / "index.html").write_text(html, encoding="utf-8")
+    return {"trial_count": len(trials)}

--- a/tests/test_voice_lab_chatterbox_killer.py
+++ b/tests/test_voice_lab_chatterbox_killer.py
@@ -1,0 +1,55 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from audio_engine.voice_lab_chatterbox_killer import experiment_spec, write_blind_player
+
+
+class VoiceLabChatterboxKillerTests(unittest.TestCase):
+    def test_spec_is_minimal_and_never_promotes_production(self):
+        spec = experiment_spec()
+        self.assertFalse(spec["production_promotion"])
+        self.assertEqual(len(spec["cases"]), 2)
+        self.assertEqual({c["id"] for c in spec["cases"]}, {"panic", "mystery"})
+        self.assertTrue(all(len(c["treatments"]) == 4 for c in spec["cases"]))
+
+    def test_panic_probe_uses_corrected_french_text(self):
+        spec = experiment_spec()
+        panic = next(c for c in spec["cases"] if c["id"] == "panic")
+        self.assertEqual(panic["text"], "Vite ! Ils arrivent ! Fermez la porte !")
+        self.assertNotIn("Courez", panic["text"])
+
+    def test_treatments_compare_edge_to_three_chatterbox_levels(self):
+        spec = experiment_spec()
+        treatments = spec["cases"][0]["treatments"]
+        self.assertEqual([t["provider"] for t in treatments].count("edge"), 1)
+        self.assertEqual([t["provider"] for t in treatments].count("chatterbox"), 3)
+        levels = [t.get("exaggeration") for t in treatments if t["provider"] == "chatterbox"]
+        self.assertEqual(levels, [0.5, 0.8, 1.2])
+
+    def test_player_contains_only_complete_cases(self):
+        spec = experiment_spec()
+        rendered = []
+        for case in spec["cases"]:
+            for treatment in case["treatments"]:
+                rendered.append({
+                    "case_id": case["id"],
+                    "treatment_id": treatment["id"],
+                    "file": f"clips/{case['id']}--{treatment['id']}.wav",
+                })
+        manifest = {**spec, "rendered": rendered}
+        with tempfile.TemporaryDirectory() as temp_value:
+            root = Path(temp_value)
+            result = write_blind_player(manifest, root)
+            self.assertEqual(result["trial_count"], 2)
+            player = (root / "index.html").read_text(encoding="utf-8")
+            self.assertIn("Prononciation invalide", player)
+            self.assertIn("Aucune acceptable", player)
+
+    def test_core_dependencies_do_not_include_chatterbox(self):
+        pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+        self.assertNotIn('"chatterbox-tts', pyproject)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
Human listening shows Edge is strong for narration and identity but weak for hard acting. Before adding a cloud dependency, challenge the best current open/local option with a tiny falsifiable experiment.

## Arbitration
- Chatterbox Multilingual V3 first: MIT, French, zero-shot cloning, local CPU path, simplest open challenger.
- CosyVoice 3 remains the semantic-instruction challenger if Chatterbox's scalar expressivity is insufficient.
- Parler-TTS remains a secondary descriptive-style option.

## What changes
- adds a **lab-only optional** Chatterbox V3 provider with lazy imports; no core dependency change
- adds a 2-case killer test using a synthetic Edge Vivienne reference identity
- cases: corrected French panic + mystery
- blind options: Edge baseline vs Chatterbox neutral / dramatic / strong
- fixed seed and explicit pronunciation-invalid outcome
- adds focused offline tests
- adds an isolated CPU GitHub Actions workflow; 8 clips / 2 human decisions
- documents the open-model arbitration

## Guardrails
- no production provider promotion
- no human voice cloning asset
- no `chatterbox-tts` in `pyproject.toml`
- heavy ML stack exists only inside the experiment workflow
