### PR TITLE
Voice Lab: validate Chatterbox V3 across voices and identity

### DIFF
--- a/.github/workflows/voice-casting-chatterbox-stage2.yml
+++ b/.github/workflows/voice-casting-chatterbox-stage2.yml
@@ -1,0 +1,128 @@
+name: Voice Casting Chatterbox V3 Stage 2
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/voice-casting-chatterbox-stage2.yml
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  chatterbox-stage2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      HF_HOME: ${{ github.workspace }}/.hf-cache
+      TOKENIZERS_PARALLELISM: "false"
+      OMP_NUM_THREADS: "2"
+      MKL_NUM_THREADS: "2"
+      CHATTERBOX_REV: 3f35dfc8fbe63e5b29793289dc68f1875bb317a5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Publish run locator immediately
+        id: locator
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ISSUE_URL=$(gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Voice Casting Chatterbox V3 stage2 running $RUN_ID" \
+            --body "Chatterbox V3 stage-2 benchmark started.\n\n- run_id: $RUN_ID\n- run: $RUN_URL\n- status: running\n- upstream revision: $CHATTERBOX_REV\n- voices: Vivienne + William\n- acting: panic, mystery, polite threat, wonder\n- identity: 4 cross-provider ABX checks\n- design: fixed winning Chatterbox bundle vs Edge baseline\n\nLab evidence only; no production promotion."
+          )
+          echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Cache public Chatterbox model files
+        uses: actions/cache@v4
+        with:
+          path: .hf-cache
+          key: chatterbox-multilingual-v3-${{ env.CHATTERBOX_REV }}
+
+      - name: Install core engine
+        run: python -m pip install --disable-pip-version-check -e .
+
+      - name: Verify stage-2 contract offline
+        run: python -m unittest tests.test_voice_lab_chatterbox_stage2 -v
+
+      - name: Install pinned upstream Chatterbox V3 source
+        run: |
+          python -m pip install --disable-pip-version-check \
+            "git+https://github.com/resemble-ai/chatterbox.git@${CHATTERBOX_REV}"
+          python -m pip check
+
+      - name: Verify V3 API and French
+        run: |
+          python - <<'PY'
+          import inspect
+          from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+          params = inspect.signature(ChatterboxMultilingualTTS.from_pretrained).parameters
+          if "t3_model" not in params:
+              raise SystemExit("Pinned source lacks the V3 selector.")
+          if "fr" not in ChatterboxMultilingualTTS.get_supported_languages():
+              raise SystemExit("Pinned source does not advertise French support.")
+          PY
+
+      - name: Render stage-2 benchmark
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from audio_engine.voice_lab_chatterbox_stage2 import render_experiment
+          result = render_experiment(Path("chatterbox-stage2-output"))
+          print(json.dumps({
+              "status": result["status"],
+              "rendered_count": result["rendered_count"],
+              "failure_count": result["failure_count"],
+          }, indent=2))
+          if result["status"] != "success":
+              print(json.dumps(result["failures"], indent=2, ensure_ascii=False))
+              raise SystemExit(1)
+          PY
+
+      - name: Upload blind-listening bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: voice-casting-chatterbox-v3-stage2
+          path: chatterbox-stage2-output/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Mark locator completed
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_URL: ${{ steps.locator.outputs.issue_url }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ISSUE_NUMBER="${ISSUE_URL##*/}"
+          gh issue edit "$ISSUE_NUMBER" --repo "${{ github.repository }}" \
+            --title "Voice Casting Chatterbox V3 stage2 completed $RUN_ID" \
+            --body "Chatterbox V3 stage-2 benchmark completed.\n\n- run_id: $RUN_ID\n- run: $RUN_URL\n- status: completed\n- artifact: voice-casting-chatterbox-v3-stage2\n- upstream revision: $CHATTERBOX_REV\n- output: 16 comparison clips + 2 synthetic Edge references\n- human boundary: 8 acting choices + 4 identity ABX choices\n\nLab evidence only; no production promotion."
+
+      - name: Mark locator failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_URL: ${{ steps.locator.outputs.issue_url }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$ISSUE_URL" ]; then exit 0; fi
+          ISSUE_NUMBER="${ISSUE_URL##*/}"
+          gh issue edit "$ISSUE_NUMBER" --repo "${{ github.repository }}" \
+            --title "Voice Casting Chatterbox V3 stage2 failed $RUN_ID" \
+            --body "Chatterbox V3 stage-2 benchmark failed.\n\n- run_id: $RUN_ID\n- run: $RUN_URL\n- status: failed\n- upstream revision: $CHATTERBOX_REV\n\nInspect the workflow logs. Lab evidence only."

--- a/docs/evidence/voice-casting-chatterbox-v3-killer-human-eval-2026-08-24.json
+++ b/docs/evidence/voice-casting-chatterbox-v3-killer-human-eval-2026-08-24.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "date": "2026-08-24",
+  "kind": "voice-casting-chatterbox-v3-killer-human-evaluation",
+  "schema": "voice-casting-chatterbox-killer-v1",
+  "evaluator_count": 1,
+  "source_run": {
+    "workflow_run_id": 32722164952,
+    "model": "Chatterbox Multilingual V3",
+    "reference_voice": "fr-FR-VivienneMultilingualNeural",
+    "reference_source": "synthetic Edge voice",
+    "language": "fr"
+  },
+  "results": [
+    {
+      "intention": "panic",
+      "text": "Vite ! Ils arrivent ! Fermez la porte !",
+      "selected": "chatterbox-dramatic",
+      "provider": "chatterbox",
+      "exaggeration": 0.8,
+      "cfg_weight": 0.3,
+      "edge_baseline_selected": false
+    },
+    {
+      "intention": "mystery",
+      "text": "Depuis trois nuits, la même lumière apparaît derrière cette fenêtre condamnée.",
+      "selected": "chatterbox-dramatic",
+      "provider": "chatterbox",
+      "exaggeration": 0.8,
+      "cfg_weight": 0.3,
+      "edge_baseline_selected": false
+    }
+  ],
+  "summary": {
+    "chatterbox_wins": 2,
+    "edge_wins": 0,
+    "trial_count": 2,
+    "winning_bundle": {
+      "exaggeration": 0.8,
+      "cfg_weight": 0.3,
+      "temperature": 0.8
+    },
+    "gate": "promising",
+    "next": "expand to two voices and four hard intentions, and add explicit cross-provider identity-continuity ABX"
+  },
+  "limitations": [
+    "One evaluator and two trials are directional evidence, not a universal quality ranking.",
+    "The killer question combined acting, naturalness, and French quality; identity continuity was not independently tested.",
+    "No production provider promotion is authorized by this evidence alone."
+  ],
+  "promotion": {
+    "automatic": false,
+    "production_provider_changed": false
+  }
+}

--- a/src/audio_engine/voice_lab_chatterbox_stage2.py
+++ b/src/audio_engine/voice_lab_chatterbox_stage2.py
@@ -1,0 +1,340 @@
+"""Stage-2 Chatterbox Multilingual V3 benchmark for the Voice Casting Lab.
+
+This follows a 2/2 human-listening win for the fixed Chatterbox dramatic bundle
+(exaggeration=0.8, cfg_weight=0.3) over Edge on Vivienne.  Stage 2 asks whether
+that result generalizes across voice gender/timbre and harder intentions, while
+adding an explicit identity-continuity ABX gate.
+
+The experiment remains lab-only and cannot promote a production provider.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import subprocess
+from pathlib import Path
+
+from imageio_ffmpeg import get_ffmpeg_exe
+
+from .providers.chatterbox_lab import ChatterboxLabProvider
+from .providers.edge import EdgeProvider
+
+
+REFERENCE_TEXT = (
+    "À l'aube, personne dans la ville ne savait encore ce qui allait se produire. "
+    "Approchez. Ce que je vais vous dire ne doit sortir d'ici sous aucun prétexte."
+)
+
+VOICES = (
+    {
+        "id": "vivienne",
+        "voice": "fr-FR-VivienneMultilingualNeural",
+        "label": "Voix 1",
+    },
+    {
+        "id": "william",
+        "voice": "en-AU-WilliamMultilingualNeural",
+        "label": "Voix 2",
+    },
+)
+
+CASES = (
+    {
+        "id": "panic",
+        "intention": "panique",
+        "text": "Vite ! Ils arrivent ! Fermez la porte !",
+    },
+    {
+        "id": "mystery",
+        "intention": "mystère",
+        "text": "Depuis trois nuits, la même lumière apparaît derrière cette fenêtre condamnée.",
+    },
+    {
+        "id": "polite-threat",
+        "intention": "menace polie",
+        "text": "Je vous conseille très sincèrement de reconsidérer votre réponse.",
+    },
+    {
+        "id": "wonder",
+        "intention": "émerveillement",
+        "text": "Regardez... On distingue toute la vallée, jusqu'aux montagnes derrière la brume.",
+    },
+)
+
+CHATTERBOX_BUNDLE = {
+    "exaggeration": 0.8,
+    "cfg_weight": 0.3,
+    "temperature": 0.8,
+    "seed": 20260824,
+}
+
+IDENTITY_INTENTIONS = ("panic", "mystery")
+
+
+def experiment_spec():
+    return {
+        "version": 1,
+        "kind": "chatterbox-v3-stage2",
+        "production_promotion": False,
+        "model": {
+            "family": "Chatterbox Multilingual",
+            "t3_model": "v3",
+            "language_id": "fr",
+            "optional_dependency": True,
+        },
+        "reference": {
+            "text": REFERENCE_TEXT,
+            "source": "synthetic-edge-reference",
+        },
+        "voices": [dict(item) for item in VOICES],
+        "cases": [dict(item) for item in CASES],
+        "chatterbox_bundle": dict(CHATTERBOX_BUNDLE),
+        "identity_intentions": list(IDENTITY_INTENTIONS),
+        "decision": {
+            "acting_pass": (
+                "Chatterbox wins at least 6 of 8 acting comparisons, with at least "
+                "2 wins for each reference voice, and no repeated French-pronunciation defect."
+            ),
+            "identity_pass": "4/4 cross-provider ABX identity decisions correct.",
+            "identity_borderline": "3/4 correct triggers a targeted identity retest, not promotion.",
+            "next_if_pass": "qualify Chatterbox as an experimental acting provider; then test age lineage.",
+            "next_if_fail": "skip tuning loops and move to semantic-instruction challenger CosyVoice 3.",
+        },
+    }
+
+
+def _convert_reference(mp3_path: Path, wav_path: Path) -> None:
+    subprocess.run(
+        [
+            get_ffmpeg_exe(),
+            "-y",
+            "-i",
+            str(mp3_path),
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            str(wav_path),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def render_experiment(output_dir, *, edge=None, chatterbox=None):
+    output_dir = Path(output_dir)
+    clips_dir = output_dir / "clips"
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    edge = edge or EdgeProvider()
+    chatterbox = chatterbox or ChatterboxLabProvider(device="cpu", t3_model="v3")
+    spec = experiment_spec()
+    references = {}
+    rendered = []
+    failures = []
+
+    for voice in spec["voices"]:
+        reference_mp3 = output_dir / f"reference-{voice['id']}-edge.mp3"
+        reference_wav = output_dir / f"reference-{voice['id']}-edge-16k.wav"
+        try:
+            edge.synthesize(
+                {
+                    "text": REFERENCE_TEXT,
+                    "voice": voice["voice"],
+                    "rate": "+0%",
+                    "pitch": "+0Hz",
+                    "volume": "+0%",
+                    "language_locale": "fr-FR",
+                },
+                reference_mp3,
+            )
+            _convert_reference(reference_mp3, reference_wav)
+            reference_mp3.unlink(missing_ok=True)
+            references[voice["id"]] = f"{reference_wav.name}"
+        except Exception as exc:
+            failures.append({"voice_id": voice["id"], "kind": "reference", "error": str(exc)})
+
+    for voice in spec["voices"]:
+        reference_file = references.get(voice["id"])
+        if not reference_file:
+            continue
+        reference_path = output_dir / reference_file
+        for case in spec["cases"]:
+            # Edge baseline
+            edge_wav = clips_dir / f"{voice['id']}--{case['id']}--edge.wav"
+            edge_mp3 = clips_dir / f"{voice['id']}--{case['id']}--edge.mp3"
+            try:
+                edge.synthesize(
+                    {
+                        "text": case["text"],
+                        "voice": voice["voice"],
+                        "rate": "+0%",
+                        "pitch": "+0Hz",
+                        "volume": "+0%",
+                        "language_locale": "fr-FR",
+                    },
+                    edge_mp3,
+                )
+                _convert_reference(edge_mp3, edge_wav)
+                edge_mp3.unlink(missing_ok=True)
+                rendered.append(
+                    {
+                        "voice_id": voice["id"],
+                        "case_id": case["id"],
+                        "provider": "edge",
+                        "file": f"clips/{edge_wav.name}",
+                    }
+                )
+            except Exception as exc:
+                failures.append(
+                    {
+                        "voice_id": voice["id"],
+                        "case_id": case["id"],
+                        "provider": "edge",
+                        "error": str(exc),
+                    }
+                )
+
+            # Fixed Chatterbox bundle that won 2/2 in the killer test.
+            chatterbox_wav = clips_dir / f"{voice['id']}--{case['id']}--chatterbox.wav"
+            try:
+                chatterbox.synthesize(
+                    {
+                        "text": case["text"],
+                        "audio_prompt_path": str(reference_path),
+                        "language_id": "fr",
+                        **CHATTERBOX_BUNDLE,
+                    },
+                    chatterbox_wav,
+                )
+                rendered.append(
+                    {
+                        "voice_id": voice["id"],
+                        "case_id": case["id"],
+                        "provider": "chatterbox",
+                        "file": f"clips/{chatterbox_wav.name}",
+                    }
+                )
+            except Exception as exc:
+                failures.append(
+                    {
+                        "voice_id": voice["id"],
+                        "case_id": case["id"],
+                        "provider": "chatterbox",
+                        "error": str(exc),
+                    }
+                )
+
+    result = {
+        **spec,
+        "status": "success" if not failures else ("partial" if rendered else "failed"),
+        "rendered_count": len(rendered),
+        "failure_count": len(failures),
+        "references": references,
+        "rendered": rendered,
+        "failures": failures,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    write_blind_player(result, output_dir)
+    return result
+
+
+def _acting_trials(manifest, randomizer):
+    rendered = {
+        (item["voice_id"], item["case_id"], item["provider"]): item["file"]
+        for item in manifest.get("rendered", [])
+    }
+    trials = []
+    for voice in manifest["voices"]:
+        for case in manifest["cases"]:
+            options = []
+            for provider in ("edge", "chatterbox"):
+                file = rendered.get((voice["id"], case["id"], provider))
+                if file:
+                    options.append({"provider": provider, "file": file})
+            if len(options) != 2:
+                continue
+            randomizer.shuffle(options)
+            trials.append(
+                {
+                    "id": f"acting-{voice['id']}--{case['id']}",
+                    "kind": "acting",
+                    "voice_id": voice["id"],
+                    "voice_label": voice["label"],
+                    "case_id": case["id"],
+                    "intention": case["intention"],
+                    "text": case["text"],
+                    "options": [
+                        {"letter": letter, **option}
+                        for letter, option in zip("AB", options)
+                    ],
+                }
+            )
+    return trials
+
+
+def _identity_trials(manifest, randomizer):
+    rendered = {
+        (item["voice_id"], item["case_id"], item["provider"]): item["file"]
+        for item in manifest.get("rendered", [])
+    }
+    voices = {item["id"]: item for item in manifest["voices"]}
+    voice_ids = list(voices)
+    trials = []
+    for reference_voice_id in voice_ids:
+        distractor_voice_id = next(item for item in voice_ids if item != reference_voice_id)
+        reference_file = manifest.get("references", {}).get(reference_voice_id)
+        if not reference_file:
+            continue
+        for case_id in manifest["identity_intentions"]:
+            same_file = rendered.get((reference_voice_id, case_id, "chatterbox"))
+            distractor_file = rendered.get((distractor_voice_id, case_id, "chatterbox"))
+            if not same_file or not distractor_file:
+                continue
+            options = [
+                {"voice_id": reference_voice_id, "same_identity": True, "file": same_file},
+                {"voice_id": distractor_voice_id, "same_identity": False, "file": distractor_file},
+            ]
+            randomizer.shuffle(options)
+            trials.append(
+                {
+                    "id": f"identity-{reference_voice_id}--{case_id}",
+                    "kind": "identity-abx",
+                    "reference_voice_id": reference_voice_id,
+                    "reference_voice_label": voices[reference_voice_id]["label"],
+                    "case_id": case_id,
+                    "reference_file": reference_file,
+                    "options": [
+                        {"letter": letter, **option}
+                        for letter, option in zip("AB", options)
+                    ],
+                    "correct": next(
+                        letter
+                        for letter, option in zip("AB", options)
+                        if option["same_identity"]
+                    ),
+                }
+            )
+    return trials
+
+
+def write_blind_player(manifest, output_dir, *, seed=20260824):
+    output_dir = Path(output_dir)
+    randomizer = random.Random(seed)
+    acting = _acting_trials(manifest, randomizer)
+    identity = _identity_trials(manifest, randomizer)
+    payload = json.dumps(
+        {"version": 1, "acting": acting, "identity": identity}, ensure_ascii=False
+    ).replace("</", "<\\/")
+    html = f"""<!doctype html><html lang='fr'><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>
+<title>Chatterbox V3 — stage 2</title>
+<style>body{{font-family:system-ui,sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem;line-height:1.45}}.card{{border:1px solid #888;border-radius:12px;padding:1rem;margin:1rem 0}}.grid{{display:grid;grid-template-columns:1fr 1fr;gap:1rem}}audio{{width:100%}}button{{padding:.7rem 1rem;margin:.25rem}}.small{{opacity:.75}}@media(max-width:650px){{.grid{{grid-template-columns:1fr}}}}</style>
+<h1>Chatterbox V3 — validation stage 2</h1><p>12 décisions : 8 sur le jeu, puis 4 sur la continuité d'identité. Les moteurs et identités candidates restent masqués.</p>
+<p id='progress'></p><div id='app'></div><button id='export'>Exporter les résultats JSON</button>
+<script>const data={payload};const KEY='voice-casting-chatterbox-stage2-v1';let state={{section:'acting',index:0,responses:{{}}}};try{{state=JSON.parse(localStorage.getItem(KEY))||state}}catch(e){{}}const app=document.getElementById('app');const progress=document.getElementById('progress');function save(){{localStorage.setItem(KEY,JSON.stringify(state));}}function currentList(){{return state.section==='acting'?data.acting:data.identity;}}function answer(id,value){{state.responses[id]=value;state.index++;const list=currentList();if(state.index>=list.length&&state.section==='acting'){{state.section='identity';state.index=0;}}save();render();}}function render(){{const list=currentList();const t=list[state.index];const done=Object.keys(state.responses).length;const total=data.acting.length+data.identity.length;progress.textContent=`Décision ${{Math.min(done+1,total)}} / ${{total}} · ${{state.section==='acting'?'jeu':'identité'}}`;if(!t){{app.innerHTML='<p>Évaluation terminée. Exportez les résultats.</p>';progress.textContent=`Terminé · ${{done}} / ${{total}}`;return;}}if(t.kind==='acting'){{const players=t.options.map(o=>`<div><h3>${{o.letter}}</h3><audio controls preload='none' src='${{o.file}}'></audio></div>`).join('');app.innerHTML=`<div class='card'><span class='small'>${{t.voice_label}}</span><h2>Quelle version joue le mieux : ${{t.intention}} ?</h2><p><em>${{t.text}}</em></p><div class='grid'>${{players}}</div><p><button data-v='A'>A est meilleure</button><button data-v='B'>B est meilleure</button><button data-v='none'>Aucune acceptable</button><button data-v='invalid-pronunciation'>Prononciation invalide</button></p></div>`;}}else{{const players=t.options.map(o=>`<div><h3>${{o.letter}}</h3><audio controls preload='none' src='${{o.file}}'></audio></div>`).join('');app.innerHTML=`<div class='card'><span class='small'>Test d'identité · ${{t.reference_voice_label}}</span><h2>Quelle proposition correspond au même personnage que la référence ?</h2><p>Référence</p><audio controls preload='none' src='${{t.reference_file}}'></audio><div class='grid'>${{players}}</div><p><button data-v='A'>A</button><button data-v='B'>B</button><button data-v='uncertain'>Impossible à déterminer</button><button data-v='invalid-pronunciation'>Prononciation invalide</button></p></div>`;}}app.querySelectorAll('button[data-v]').forEach(b=>b.onclick=()=>answer(t.id,b.dataset.v));window.scrollTo({{top:0,behavior:'smooth'}});}}document.getElementById('export').onclick=()=>{{const result={{schema:'voice-casting-chatterbox-stage2-v1',exported_at:new Date().toISOString(),responses:state.responses,mapping:{{acting:data.acting,identity:data.identity}}}};const blob=new Blob([JSON.stringify(result,null,2)],{{type:'application/json'}});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='voice-casting-chatterbox-stage2-results.json';a.click();setTimeout(()=>URL.revokeObjectURL(a.href),1000);}};render();</script></html>"""
+    (output_dir / "index.html").write_text(html, encoding="utf-8")
+    return {"acting_trial_count": len(acting), "identity_trial_count": len(identity)}

--- a/tests/test_voice_lab_chatterbox_stage2.py
+++ b/tests/test_voice_lab_chatterbox_stage2.py
@@ -1,0 +1,53 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from audio_engine.voice_lab_chatterbox_stage2 import experiment_spec, render_experiment
+
+
+class FakeProvider:
+    def __init__(self):
+        self.segments = []
+
+    def synthesize(self, segment, path):
+        self.segments.append(dict(segment))
+        Path(path).write_bytes(b"audio")
+
+
+class ChatterboxStage2Tests(unittest.TestCase):
+    def test_spec_is_two_voices_four_intentions_and_non_promoting(self):
+        spec = experiment_spec()
+        self.assertFalse(spec["production_promotion"])
+        self.assertEqual(len(spec["voices"]), 2)
+        self.assertEqual(len(spec["cases"]), 4)
+        self.assertEqual(spec["chatterbox_bundle"]["exaggeration"], 0.8)
+        self.assertEqual(spec["chatterbox_bundle"]["cfg_weight"], 0.3)
+        self.assertEqual(spec["identity_intentions"], ["panic", "mystery"])
+
+    def test_render_creates_16_comparison_clips_and_12_blind_trials(self):
+        edge = FakeProvider()
+        chatterbox = FakeProvider()
+        with tempfile.TemporaryDirectory() as temp_value:
+            root = Path(temp_value)
+            with mock.patch(
+                "audio_engine.voice_lab_chatterbox_stage2._convert_reference",
+                side_effect=lambda source, target: Path(target).write_bytes(b"wav"),
+            ):
+                result = render_experiment(root, edge=edge, chatterbox=chatterbox)
+            self.assertEqual(result["status"], "success")
+            self.assertEqual(result["rendered_count"], 16)
+            self.assertEqual(result["failure_count"], 0)
+            html = (root / "index.html").read_text(encoding="utf-8")
+            self.assertIn("12 décisions", html)
+            self.assertIn("localStorage", html)
+            self.assertIn("voice-casting-chatterbox-stage2-v1", html)
+            self.assertEqual(len(edge.segments), 10)  # 2 references + 8 baselines
+            self.assertEqual(len(chatterbox.segments), 8)
+            self.assertTrue(all(s.get("language_id") == "fr" for s in chatterbox.segments))
+            self.assertTrue(all(s.get("exaggeration") == 0.8 for s in chatterbox.segments))
+            self.assertTrue(all(s.get("cfg_weight") == 0.3 for s in chatterbox.segments))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
The Chatterbox V3 killer test won 2/2 human-listening comparisons over Edge on Vivienne using the same fixed bundle (`exaggeration=0.8`, `cfg_weight=0.3`). That is promising but too small to justify production use.

## What
- persist the killer human evidence without the embedded audio payload;
- add a stage-2 benchmark with Vivienne + William;
- compare the fixed winning Chatterbox bundle vs Edge baseline on panic, mystery, polite threat, and wonder;
- add 4 explicit cross-provider ABX identity-continuity trials;
- autosave listening decisions in localStorage;
- keep Chatterbox optional/lab-only and pinned to the tested V3 upstream revision;
- add offline tests and an isolated Actions workflow.

## Promotion gate
No automatic production promotion. Stage 2 requires strong acting wins plus explicit identity continuity; otherwise the lab moves to CosyVoice 3 rather than entering a tuning loop.