### PR TITLE
LAB: freeze Qwen3 character identity before rendering

### DIFF
--- a/docs/VOICE_CASTING_OPEN_MODELS.md
+++ b/docs/VOICE_CASTING_OPEN_MODELS.md
@@ -56,7 +56,7 @@ VoiceDesign human result on two deliberately similar French female characters:
 
 Decision: the **identity-by-description + fixed seed strategy is eliminated**. The result nevertheless establishes that Qwen3 has a very strong French expressive signal worth preserving through a more explicit speaker-identity mechanism.
 
-### Qwen3-TTS Base 1.7B — x-vector stable-identity experiment, borderline
+### Qwen3-TTS Base 1.7B — x-vector stable identity qualified in Lab
 
 The Base model exposes `x_vector_only_mode=True`, where only the frozen speaker embedding is used; reference speech codes and reference text are not carried as ICL style conditioning. This directly tests the desired separation between **who is speaking** and **how the line is performed**.
 
@@ -68,20 +68,42 @@ First human result:
 - French: `4/4` equivalent, zero invalid-French veto;
 - identity ABX: `3/4` correct.
 
-This is **BORDERLINE, not PASS**. The single miss was Claire under panic. Per the predeclared rule, exactly one narrow high-arousal identity confirmation was generated with the same frozen anchors and no tuning.
+That result was predeclared BORDERLINE because the sole miss was Claire under panic. The one permitted confirmation therefore used a new high-arousal sentence with the same frozen anchors and no tuning.
 
-Canonical confirmation run: `32772435007`  
+Confirmation run: `32772435007`  
 Artifact: `voice-casting-qwen3-xvector-identity-confirm`  
-Output: two new high-arousal clips + the two frozen references.  
-Human decision still required: `2/2` identity plus no French defect to qualify this architecture in the Lab.
+Artifact digest: `sha256:7f75914089e46fa447fdfe2e770213a9a0778a1df7b732510964b16ed8a426c0`
 
-No production promotion is implied by a confirmation pass.
+Human confirmation result:
 
-## Next decision tree
+- Claire / high arousal: identity correct;
+- Lucie / high arousal: identity correct;
+- French: both generated samples judged correct/natural;
+- final confirmation: **2/2 identity, 0 French veto**.
 
-If the narrow Qwen3 x-vector confirmation passes, the next work is a **minimal Lab-only character contract**: frozen character anchor / speaker prompt + generated line, followed by a small composition test across a broader emotional set. Production Edge remains unchanged until an explicit later promotion gate.
+Decision: **PASS the predeclared confirmation rule.** Qwen3 Base x-vector-only is qualified in Voice Casting Lab as a stable-character strategy across the tested panic/high-arousal and polite-threat material. This is not a production promotion and does not establish age-lineage support.
 
-If the confirmation fails, the x-vector stable-character strategy is eliminated without tuning. A distinct architecture may then be evaluated, but only after verifying French support, licensing, identity mechanism and operational cost. Do not resurrect Chatterbox, CosyVoice or VoxCPM2 tuning.
+Qualified anchor hashes used by the confirmation:
+
+- Claire: `1012fdc137a848e71a9403140267e62140ad87b14ee9a3236e106b57775afa55`;
+- Lucie: `f42c27ce633e0d009a95079cdfddc605772bbf48e9806fba6fba3749e5aa1ee2`.
+
+## Current implementation boundary
+
+The next architecture is deliberately small: a **Lab-only frozen character pack** containing a character id, one approved anchor, its SHA-256, and the explicit `x_vector_only` identity mode.
+
+Rules:
+
+- anchor generation is outside the pack and never happens silently;
+- the pack copies and hashes an already approved anchor;
+- hash mismatch aborts before a model is loaded;
+- one speaker prompt is reused for all lines of a character;
+- individual synthesis failures may yield a `partial` render rather than discard successful lines;
+- the anchor hash is verified again after rendering;
+- there is no fallback to another voice or provider;
+- `production_promoted=false` and `age_lineage=false` remain explicit.
+
+Production Edge is untouched until a later explicit promotion gate. Long-form fatigue and age continuity remain separate unresolved questions.
 
 ## Governance
 

--- a/docs/VOICE_CHARACTER_LAB.md
+++ b/docs/VOICE_CHARACTER_LAB.md
@@ -1,0 +1,94 @@
+# Frozen character packs — Voice Casting Lab
+
+Status: experimental only. This contract does not alter the production renderer.
+
+## Why this exists
+
+The Qwen3 x-vector experiments established a useful separation between speaker identity and line performance. The practical requirement is therefore not “pick a voice for every line”; it is “freeze a character once, then render many lines without silently recasting that character.”
+
+A character pack is the smallest durable object that represents that promise.
+
+## Pack contents
+
+A pack contains exactly two durable files:
+
+- `character.json` — the identity contract;
+- `anchor.wav` — one already approved identity anchor.
+
+The pack does **not** generate its own anchor. `freeze_character_identity(...)` copies an existing approved WAV, computes its SHA-256 and records it. If the destination already contains a character pack, replacement is refused rather than performed silently.
+
+Example shape:
+
+```json
+{
+  "schema": "audio-engine-character-lab-v1",
+  "character_id": "claire",
+  "provider": "qwen3-xvector-lab",
+  "identity_mode": "x_vector_only",
+  "language": "French",
+  "base_seed": 20260824,
+  "anchor": {
+    "file": "anchor.wav",
+    "sha256": "...64 hex characters...",
+    "regeneration": false
+  },
+  "source": {
+    "qualification_issue": 65
+  },
+  "claims": {
+    "stable_character": true,
+    "age_lineage": false,
+    "production_promoted": false
+  }
+}
+```
+
+## Fail-closed identity rules
+
+Identity integrity is stricter than line-generation availability.
+
+Before any heavy model is initialized:
+
+1. schema and provider must be the qualified Lab values;
+2. `identity_mode` must be exactly `x_vector_only`;
+3. the anchor must remain inside the pack;
+4. anchor regeneration must be explicitly `false`;
+5. the anchor SHA-256 must match exactly;
+6. the contract may not claim age-lineage or production promotion.
+
+The hash is checked again after all line renders. If it changed, the render is rejected because its identity evidence is no longer trustworthy.
+
+There is no fallback to another speaker, provider or anchor.
+
+## Best-effort line rendering
+
+Once identity has passed the fail-closed gate, individual synthesis failures are treated differently. A failed line is recorded in `manifest.json`, later lines continue, and the overall status becomes `partial` when at least one line succeeded.
+
+This distinction is intentional:
+
+- **identity uncertainty** can silently corrupt a character and therefore aborts;
+- **one bad generated line** is visible and repairable and therefore must not erase an otherwise usable batch.
+
+One reusable Qwen3 identity prompt is built per character render. Per-line seeds are deterministic from the character, line id and text unless an explicit seed is provided.
+
+## What qualification currently supports
+
+Evidence on 2026-08-24 supports the following Lab claim for Qwen3 Base x-vector-only:
+
+- strong French acting signal on the tested hard intentions;
+- no French veto in the qualified x-vector trials;
+- identity result `3/4` in the initial killer followed by the predeclared independent high-arousal confirmation at `2/2`.
+
+That is sufficient to experiment with frozen characters in the Lab.
+
+It does **not** establish:
+
+- production readiness;
+- age continuity;
+- arbitrary emotion coverage;
+- long-form fatigue performance;
+- a guarantee that every generated take is artistically acceptable.
+
+## Storage direction
+
+Generated audio and character anchors should stay out of the source repository. A later product integration can place character packs in a private/protected asset source or durable release artifact and refer to them by immutable digest. The source repository should retain contracts, code and qualification receipts rather than generated media.

--- a/docs/evidence/qwen3-xvector-qualification-2026-08-24.json
+++ b/docs/evidence/qwen3-xvector-qualification-2026-08-24.json
@@ -1,0 +1,51 @@
+{
+  "schema": "voice-casting-qualification-receipt-v1",
+  "date": "2026-08-24",
+  "candidate": "Qwen3-TTS Base 1.7B x-vector-only",
+  "source": {
+    "repository": "QwenLM/Qwen3-TTS",
+    "revision": "022e286b98fbec7e1e916cb940cdf532cd9f488e",
+    "model": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+    "model_revision": "74a6279626edc2d5a787d5b6467668eba0b86ef6",
+    "license": "Apache-2.0"
+  },
+  "identity_mode": "x_vector_only",
+  "initial_killer": {
+    "issue": 63,
+    "acting_vs_edge": {"qwen3_wins": 4, "total": 4},
+    "french": {"acceptable": 4, "total": 4, "invalid_vetoes": 0},
+    "identity": {"correct": 3, "total": 4},
+    "verdict": "borderline",
+    "rule": "Exactly one independent high-arousal identity confirmation; no tuning."
+  },
+  "narrow_confirmation": {
+    "issue": 65,
+    "run_id": 32772435007,
+    "artifact": "voice-casting-qwen3-xvector-identity-confirm",
+    "artifact_digest": "sha256:7f75914089e46fa447fdfe2e770213a9a0778a1df7b732510964b16ed8a426c0",
+    "probe": "Non ! Ne restez pas là ! Sortez, maintenant !",
+    "identity": {"correct": 2, "total": 2},
+    "french": {"acceptable": 2, "total": 2, "invalid_vetoes": 0},
+    "verdict": "pass"
+  },
+  "anchors": {
+    "claire": "1012fdc137a848e71a9403140267e62140ad87b14ee9a3236e106b57775afa55",
+    "lucie": "f42c27ce633e0d009a95079cdfddc605772bbf48e9806fba6fba3749e5aa1ee2"
+  },
+  "qualified_claims": {
+    "lab_stable_character": true,
+    "tested_high_arousal_identity": true,
+    "tested_polite_threat_identity": true,
+    "french_on_tested_material": true,
+    "production_promoted": false,
+    "age_lineage": false,
+    "long_form_qualified": false
+  },
+  "governance": {
+    "identity_first": true,
+    "no_silent_recast": true,
+    "no_anchor_regeneration": true,
+    "no_tuning_after_confirmation": true,
+    "production_edge_unchanged": true
+  }
+}

--- a/src/audio_engine/providers/qwen3_xvector_lab.py
+++ b/src/audio_engine/providers/qwen3_xvector_lab.py
@@ -1,0 +1,83 @@
+"""Optional Qwen3-TTS Base x-vector provider for Voice Casting Lab only.
+
+Only the frozen speaker embedding is carried from the reference anchor. Reference
+speech codes and text are deliberately excluded as style conditioning.
+"""
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+
+class Qwen3XVectorLabProvider:
+    name = "qwen3-xvector-lab"
+    processing = "local-optional"
+    identity_mode = "x_vector_only"
+
+    def __init__(self, *, model_dir, device: str = "cpu"):
+        try:
+            import numpy as np
+            import soundfile as sf
+            import torch
+            from qwen_tts import Qwen3TTSModel
+            from transformers.utils import logging as transformers_logging
+        except ImportError as exc:
+            raise RuntimeError(
+                "Qwen3 x-vector lab provider requires the isolated qwen-tts environment"
+            ) from exc
+        model_path = Path(model_dir)
+        if not model_path.exists():
+            raise FileNotFoundError(model_path)
+        self._np, self._sf, self._torch = np, sf, torch
+        self._transformers_logging = transformers_logging
+        self.device = device
+        self.model = Qwen3TTSModel.from_pretrained(
+            str(model_path),
+            device_map=device,
+            dtype=torch.bfloat16,
+            attn_implementation="eager",
+        )
+
+    def build_identity_prompt(self, reference_wav_path):
+        reference = Path(reference_wav_path)
+        if not reference.exists():
+            raise FileNotFoundError(reference)
+        return self.model.create_voice_clone_prompt(
+            ref_audio=str(reference),
+            ref_text=None,
+            x_vector_only_mode=True,
+        )
+
+    def synthesize(self, segment: dict, path, *, voice_clone_prompt) -> None:
+        text = str(segment.get("text") or "").strip()
+        if not text:
+            raise ValueError("Qwen3 x-vector clone requires text")
+        seed = int(segment.get("seed", 20260824))
+        random.seed(seed)
+        self._np.random.seed(seed % (2**32 - 1))
+        self._torch.manual_seed(seed)
+
+        log = self._transformers_logging
+        was_enabled = True
+        checker = getattr(log, "is_progress_bar_enabled", None)
+        if callable(checker):
+            was_enabled = bool(checker())
+        disable = getattr(log, "disable_progress_bar", None)
+        enable = getattr(log, "enable_progress_bar", None)
+        if callable(disable):
+            disable()
+        try:
+            wavs, sr = self.model.generate_voice_clone(
+                text=text,
+                language=segment.get("language", "French"),
+                voice_clone_prompt=voice_clone_prompt,
+                non_streaming_mode=True,
+                do_sample=True,
+                max_new_tokens=int(segment.get("max_new_tokens", 768)),
+            )
+        finally:
+            if was_enabled and callable(enable):
+                enable()
+        output = Path(path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        self._sf.write(str(output), wavs[0], sr)

--- a/src/audio_engine/voice_character_lab.py
+++ b/src/audio_engine/voice_character_lab.py
@@ -1,0 +1,206 @@
+"""Minimal frozen-character contract for qualified Voice Casting Lab renderers.
+
+Identity is fail-closed: the anchor file must match its declared SHA-256 before
+any model is loaded and after rendering. Individual line synthesis is best-effort
+so one residual generation failure does not erase successful lines.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import time
+from pathlib import Path
+
+from .providers.qwen3_xvector_lab import Qwen3XVectorLabProvider
+
+SCHEMA = "audio-engine-character-lab-v1"
+PROVIDER = "qwen3-xvector-lab"
+IDENTITY_MODE = "x_vector_only"
+DEFAULT_LANGUAGE = "French"
+
+
+class CharacterLabError(ValueError):
+    pass
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _slug(value: str) -> str:
+    value = re.sub(r"[^a-zA-Z0-9._-]+", "-", str(value)).strip("-")
+    return value or "line"
+
+
+def _seed(base_seed: int, character_id: str, line_id: str, text: str) -> int:
+    payload = f"{base_seed}\0{character_id}\0{line_id}\0{text}".encode("utf-8")
+    return int.from_bytes(hashlib.sha256(payload).digest()[:4], "big")
+
+
+def freeze_character_identity(
+    character_id,
+    anchor_path,
+    output_dir,
+    *,
+    base_seed=20260824,
+    language=DEFAULT_LANGUAGE,
+    source=None,
+):
+    """Copy an already-approved anchor into a self-contained immutable lab pack.
+
+    This function never synthesizes or regenerates an anchor.
+    """
+    character_id = str(character_id or "").strip()
+    if not character_id:
+        raise CharacterLabError("character_id is required")
+    anchor_path = Path(anchor_path)
+    if not anchor_path.is_file():
+        raise FileNotFoundError(anchor_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    frozen_anchor = output_dir / "anchor.wav"
+    spec_path = output_dir / "character.json"
+    if frozen_anchor.exists() or spec_path.exists():
+        raise CharacterLabError("character pack already exists; silent replacement is forbidden")
+    shutil.copy2(anchor_path, frozen_anchor)
+    digest = _sha256(frozen_anchor)
+    spec = {
+        "schema": SCHEMA,
+        "character_id": character_id,
+        "provider": PROVIDER,
+        "identity_mode": IDENTITY_MODE,
+        "language": language,
+        "base_seed": int(base_seed),
+        "anchor": {"file": "anchor.wav", "sha256": digest, "regeneration": False},
+        "source": source or {},
+        "claims": {
+            "stable_character": True,
+            "age_lineage": False,
+            "production_promoted": False,
+        },
+    }
+    spec_path.write_text(json.dumps(spec, ensure_ascii=False, indent=2), encoding="utf-8")
+    return {"status": "frozen", "spec": str(spec_path), "anchor_sha256": digest}
+
+
+def load_character_identity(spec_path):
+    spec_path = Path(spec_path)
+    data = json.loads(spec_path.read_text(encoding="utf-8"))
+    if data.get("schema") != SCHEMA:
+        raise CharacterLabError(f"unsupported character schema: {data.get('schema')!r}")
+    if not str(data.get("character_id") or "").strip():
+        raise CharacterLabError("character_id is required")
+    if data.get("provider") != PROVIDER:
+        raise CharacterLabError("qualified character pack requires qwen3-xvector-lab")
+    if data.get("identity_mode") != IDENTITY_MODE:
+        raise CharacterLabError("qualified character pack requires x_vector_only identity mode")
+    claims = data.get("claims") or {}
+    if claims.get("production_promoted") is True:
+        raise CharacterLabError("lab character contract cannot claim production promotion")
+    if claims.get("age_lineage") is True:
+        raise CharacterLabError("age-lineage is not qualified for this character contract")
+    anchor = data.get("anchor") or {}
+    if anchor.get("regeneration") is not False:
+        raise CharacterLabError("anchor regeneration must be explicitly forbidden")
+    expected = str(anchor.get("sha256") or "").lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", expected):
+        raise CharacterLabError("anchor.sha256 must be a lowercase SHA-256 digest")
+    anchor_path = spec_path.parent / str(anchor.get("file") or "")
+    if not anchor_path.is_file():
+        raise FileNotFoundError(anchor_path)
+    actual = _sha256(anchor_path)
+    if actual != expected:
+        raise CharacterLabError(
+            f"frozen anchor hash mismatch for {data['character_id']}: expected {expected}, got {actual}"
+        )
+    return data, anchor_path
+
+
+def render_character_lines(
+    spec_path,
+    lines,
+    output_dir,
+    *,
+    provider=None,
+    model_dir=None,
+):
+    """Render multiple lines from one verified frozen identity.
+
+    A bad anchor aborts before provider/model initialization. A line-level synthesis
+    error is recorded and the remaining lines continue. There is no provider fallback.
+    """
+    spec, anchor_path = load_character_identity(spec_path)
+    expected_hash = spec["anchor"]["sha256"]
+    if provider is None:
+        if model_dir is None:
+            raise CharacterLabError("model_dir is required when provider is not injected")
+        provider = Qwen3XVectorLabProvider(model_dir=model_dir, device="cpu")
+    if getattr(provider, "identity_mode", IDENTITY_MODE) != IDENTITY_MODE:
+        raise CharacterLabError("provider must use x_vector_only identity mode")
+
+    prompt = provider.build_identity_prompt(anchor_path)
+    output_dir = Path(output_dir)
+    clips_dir = output_dir / "clips"
+    clips_dir.mkdir(parents=True, exist_ok=True)
+    base_seed = int(spec.get("base_seed", 20260824))
+    language = spec.get("language") or DEFAULT_LANGUAGE
+    rendered, failures = [], []
+    started = time.monotonic()
+
+    for index, raw in enumerate(lines, 1):
+        if not isinstance(raw, dict):
+            raise CharacterLabError(f"line {index} must be an object")
+        line_id = str(raw.get("id") or f"line-{index}").strip()
+        text = str(raw.get("text") or "").strip()
+        if not text:
+            raise CharacterLabError(f"line {line_id!r} has empty text")
+        seed = int(raw.get("seed", _seed(base_seed, spec["character_id"], line_id, text)))
+        out = clips_dir / f"{index:03d}--{_slug(line_id)}.wav"
+        clip_started = time.monotonic()
+        try:
+            provider.synthesize(
+                {"text": text, "language": raw.get("language", language), "seed": seed},
+                out,
+                voice_clone_prompt=prompt,
+            )
+            rendered.append({
+                "id": line_id,
+                "text": text,
+                "file": str(out.relative_to(output_dir)),
+                "seed": seed,
+                "render_seconds": round(time.monotonic() - clip_started, 2),
+            })
+        except Exception as exc:
+            failures.append({"id": line_id, "text": text, "seed": seed, "error": str(exc)})
+
+    final_hash = _sha256(anchor_path)
+    if final_hash != expected_hash:
+        raise CharacterLabError("frozen anchor changed during rendering; results are not trustworthy")
+
+    result = {
+        "schema": "audio-engine-character-lab-render-v1",
+        "status": "success" if not failures else ("partial" if rendered else "failed"),
+        "character_id": spec["character_id"],
+        "provider": PROVIDER,
+        "identity_mode": IDENTITY_MODE,
+        "anchor_sha256": expected_hash,
+        "anchor_verified_before_and_after": True,
+        "production_promoted": False,
+        "age_lineage": False,
+        "rendered_count": len(rendered),
+        "failure_count": len(failures),
+        "rendered": rendered,
+        "failures": failures,
+        "render_total_seconds": round(time.monotonic() - started, 2),
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "manifest.json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return result

--- a/src/audio_engine/voice_character_lab.py
+++ b/src/audio_engine/voice_character_lab.py
@@ -43,6 +43,20 @@ def _seed(base_seed: int, character_id: str, line_id: str, text: str) -> int:
     return int.from_bytes(hashlib.sha256(payload).digest()[:4], "big")
 
 
+def _resolve_anchor(spec_path: Path, anchor_file: str) -> Path:
+    anchor_file = str(anchor_file or "").strip()
+    relative = Path(anchor_file)
+    if not anchor_file or relative.is_absolute() or ".." in relative.parts:
+        raise CharacterLabError("anchor.file must stay inside the character pack")
+    pack_root = spec_path.parent.resolve()
+    anchor_path = (pack_root / relative).resolve()
+    try:
+        anchor_path.relative_to(pack_root)
+    except ValueError as exc:
+        raise CharacterLabError("anchor.file must stay inside the character pack") from exc
+    return anchor_path
+
+
 def freeze_character_identity(
     character_id,
     anchor_path,
@@ -111,7 +125,7 @@ def load_character_identity(spec_path):
     expected = str(anchor.get("sha256") or "").lower()
     if not re.fullmatch(r"[0-9a-f]{64}", expected):
         raise CharacterLabError("anchor.sha256 must be a lowercase SHA-256 digest")
-    anchor_path = spec_path.parent / str(anchor.get("file") or "")
+    anchor_path = _resolve_anchor(spec_path, anchor.get("file"))
     if not anchor_path.is_file():
         raise FileNotFoundError(anchor_path)
     actual = _sha256(anchor_path)
@@ -141,8 +155,8 @@ def render_character_lines(
         if model_dir is None:
             raise CharacterLabError("model_dir is required when provider is not injected")
         provider = Qwen3XVectorLabProvider(model_dir=model_dir, device="cpu")
-    if getattr(provider, "identity_mode", IDENTITY_MODE) != IDENTITY_MODE:
-        raise CharacterLabError("provider must use x_vector_only identity mode")
+    if getattr(provider, "identity_mode", None) != IDENTITY_MODE:
+        raise CharacterLabError("provider must explicitly use x_vector_only identity mode")
 
     prompt = provider.build_identity_prompt(anchor_path)
     output_dir = Path(output_dir)
@@ -160,7 +174,7 @@ def render_character_lines(
         text = str(raw.get("text") or "").strip()
         if not text:
             raise CharacterLabError(f"line {line_id!r} has empty text")
-        seed = int(raw.get("seed", _seed(base_seed, spec["character_id"], line_id, text)))
+        seed = int(raw["seed"]) if "seed" in raw else _seed(base_seed, spec["character_id"], line_id, text)
         out = clips_dir / f"{index:03d}--{_slug(line_id)}.wav"
         clip_started = time.monotonic()
         try:

--- a/src/audio_engine/voice_character_lab.py
+++ b/src/audio_engine/voice_character_lab.py
@@ -33,6 +33,13 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+def _assert_wave(path: Path) -> None:
+    with path.open("rb") as stream:
+        header = stream.read(12)
+    if len(header) < 12 or header[:4] != b"RIFF" or header[8:12] != b"WAVE":
+        raise CharacterLabError(f"character anchor must be a RIFF/WAVE file: {path}")
+
+
 def _slug(value: str) -> str:
     value = re.sub(r"[^a-zA-Z0-9._-]+", "-", str(value)).strip("-")
     return value or "line"
@@ -57,6 +64,36 @@ def _resolve_anchor(spec_path: Path, anchor_file: str) -> Path:
     return anchor_path
 
 
+def _normalize_lines(lines, *, character_id: str, base_seed: int, language: str):
+    normalized = []
+    seen = set()
+    for index, raw in enumerate(lines, 1):
+        if not isinstance(raw, dict):
+            raise CharacterLabError(f"line {index} must be an object")
+        line_id = str(raw.get("id") or f"line-{index}").strip()
+        if not line_id:
+            raise CharacterLabError(f"line {index} has empty id")
+        if line_id in seen:
+            raise CharacterLabError(f"duplicate line id: {line_id}")
+        seen.add(line_id)
+        text = str(raw.get("text") or "").strip()
+        if not text:
+            raise CharacterLabError(f"line {line_id!r} has empty text")
+        line_language = str(raw.get("language", language))
+        if line_language != language:
+            raise CharacterLabError(
+                f"line {line_id!r} changes language from qualified {language!r} to {line_language!r}"
+            )
+        try:
+            seed = int(raw["seed"]) if "seed" in raw else _seed(base_seed, character_id, line_id, text)
+        except (TypeError, ValueError) as exc:
+            raise CharacterLabError(f"line {line_id!r} has invalid seed") from exc
+        normalized.append({"id": line_id, "text": text, "language": line_language, "seed": seed})
+    if not normalized:
+        raise CharacterLabError("at least one line is required")
+    return normalized
+
+
 def freeze_character_identity(
     character_id,
     anchor_path,
@@ -73,9 +110,12 @@ def freeze_character_identity(
     character_id = str(character_id or "").strip()
     if not character_id:
         raise CharacterLabError("character_id is required")
+    if language != DEFAULT_LANGUAGE:
+        raise CharacterLabError("current stable-character qualification is French only")
     anchor_path = Path(anchor_path)
     if not anchor_path.is_file():
         raise FileNotFoundError(anchor_path)
+    _assert_wave(anchor_path)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     frozen_anchor = output_dir / "anchor.wav"
@@ -105,6 +145,8 @@ def freeze_character_identity(
 
 def load_character_identity(spec_path):
     spec_path = Path(spec_path)
+    if not spec_path.is_file():
+        raise FileNotFoundError(spec_path)
     data = json.loads(spec_path.read_text(encoding="utf-8"))
     if data.get("schema") != SCHEMA:
         raise CharacterLabError(f"unsupported character schema: {data.get('schema')!r}")
@@ -114,11 +156,15 @@ def load_character_identity(spec_path):
         raise CharacterLabError("qualified character pack requires qwen3-xvector-lab")
     if data.get("identity_mode") != IDENTITY_MODE:
         raise CharacterLabError("qualified character pack requires x_vector_only identity mode")
+    if data.get("language") != DEFAULT_LANGUAGE:
+        raise CharacterLabError("current stable-character qualification is French only")
     claims = data.get("claims") or {}
-    if claims.get("production_promoted") is True:
-        raise CharacterLabError("lab character contract cannot claim production promotion")
-    if claims.get("age_lineage") is True:
-        raise CharacterLabError("age-lineage is not qualified for this character contract")
+    if claims.get("stable_character") is not True:
+        raise CharacterLabError("stable_character must be explicitly true")
+    if claims.get("production_promoted") is not False:
+        raise CharacterLabError("production_promoted must be explicitly false in the Lab contract")
+    if claims.get("age_lineage") is not False:
+        raise CharacterLabError("age_lineage must be explicitly false until separately qualified")
     anchor = data.get("anchor") or {}
     if anchor.get("regeneration") is not False:
         raise CharacterLabError("anchor regeneration must be explicitly forbidden")
@@ -128,6 +174,7 @@ def load_character_identity(spec_path):
     anchor_path = _resolve_anchor(spec_path, anchor.get("file"))
     if not anchor_path.is_file():
         raise FileNotFoundError(anchor_path)
+    _assert_wave(anchor_path)
     actual = _sha256(anchor_path)
     if actual != expected:
         raise CharacterLabError(
@@ -146,11 +193,30 @@ def render_character_lines(
 ):
     """Render multiple lines from one verified frozen identity.
 
-    A bad anchor aborts before provider/model initialization. A line-level synthesis
-    error is recorded and the remaining lines continue. There is no provider fallback.
+    Contract and anchor errors abort before provider/model initialization. A genuine
+    line-level synthesis error is recorded and the remaining lines continue. There
+    is no provider fallback.
     """
+    spec_path = Path(spec_path)
     spec, anchor_path = load_character_identity(spec_path)
     expected_hash = spec["anchor"]["sha256"]
+    base_seed = int(spec.get("base_seed", 20260824))
+    language = spec["language"]
+    normalized_lines = _normalize_lines(
+        lines,
+        character_id=spec["character_id"],
+        base_seed=base_seed,
+        language=language,
+    )
+
+    output_dir = Path(output_dir)
+    pack_root = spec_path.parent.resolve()
+    output_root = output_dir.resolve()
+    if output_root == pack_root or pack_root in output_root.parents:
+        raise CharacterLabError("render output must be outside the immutable character pack")
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise CharacterLabError("render output directory must be empty")
+
     if provider is None:
         if model_dir is None:
             raise CharacterLabError("model_dir is required when provider is not injected")
@@ -159,39 +225,32 @@ def render_character_lines(
         raise CharacterLabError("provider must explicitly use x_vector_only identity mode")
 
     prompt = provider.build_identity_prompt(anchor_path)
-    output_dir = Path(output_dir)
     clips_dir = output_dir / "clips"
     clips_dir.mkdir(parents=True, exist_ok=True)
-    base_seed = int(spec.get("base_seed", 20260824))
-    language = spec.get("language") or DEFAULT_LANGUAGE
     rendered, failures = [], []
     started = time.monotonic()
 
-    for index, raw in enumerate(lines, 1):
-        if not isinstance(raw, dict):
-            raise CharacterLabError(f"line {index} must be an object")
-        line_id = str(raw.get("id") or f"line-{index}").strip()
-        text = str(raw.get("text") or "").strip()
-        if not text:
-            raise CharacterLabError(f"line {line_id!r} has empty text")
-        seed = int(raw["seed"]) if "seed" in raw else _seed(base_seed, spec["character_id"], line_id, text)
-        out = clips_dir / f"{index:03d}--{_slug(line_id)}.wav"
+    for index, line in enumerate(normalized_lines, 1):
+        out = clips_dir / f"{index:03d}--{_slug(line['id'])}.wav"
         clip_started = time.monotonic()
         try:
             provider.synthesize(
-                {"text": text, "language": raw.get("language", language), "seed": seed},
+                {"text": line["text"], "language": line["language"], "seed": line["seed"]},
                 out,
                 voice_clone_prompt=prompt,
             )
             rendered.append({
-                "id": line_id,
-                "text": text,
+                "id": line["id"],
+                "text": line["text"],
                 "file": str(out.relative_to(output_dir)),
-                "seed": seed,
+                "seed": line["seed"],
                 "render_seconds": round(time.monotonic() - clip_started, 2),
             })
         except Exception as exc:
-            failures.append({"id": line_id, "text": text, "seed": seed, "error": str(exc)})
+            out.unlink(missing_ok=True)
+            failures.append(
+                {"id": line["id"], "text": line["text"], "seed": line["seed"], "error": str(exc)}
+            )
 
     final_hash = _sha256(anchor_path)
     if final_hash != expected_hash:
@@ -213,7 +272,6 @@ def render_character_lines(
         "failures": failures,
         "render_total_seconds": round(time.monotonic() - started, 2),
     }
-    output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "manifest.json").write_text(
         json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
     )

--- a/tests/test_voice_character_lab.py
+++ b/tests/test_voice_character_lab.py
@@ -1,0 +1,147 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from audio_engine.voice_character_lab import (
+    CharacterLabError,
+    freeze_character_identity,
+    load_character_identity,
+    render_character_lines,
+)
+
+
+class _FakeProvider:
+    identity_mode = "x_vector_only"
+
+    def __init__(self, fail_id=None):
+        self.fail_id = fail_id
+        self.prompt_calls = 0
+        self.calls = []
+
+    def build_identity_prompt(self, anchor):
+        self.prompt_calls += 1
+        return {"anchor": Path(anchor).name}
+
+    def synthesize(self, segment, path, *, voice_clone_prompt):
+        self.calls.append((segment.copy(), voice_clone_prompt.copy()))
+        if self.fail_id and self.fail_id in str(segment["text"]):
+            raise RuntimeError("synthetic line failure")
+        Path(path).write_bytes((segment["text"] + str(segment["seed"])).encode())
+
+
+class CharacterLabTests(unittest.TestCase):
+    def _pack(self, root):
+        source = root / "source.wav"
+        source.write_bytes(b"approved-french-anchor")
+        pack = root / "pack"
+        result = freeze_character_identity(
+            "claire",
+            source,
+            pack,
+            base_seed=42,
+            source={"qualification_issue": 65},
+        )
+        return source, pack, result
+
+    def test_freeze_creates_hash_bound_non_production_pack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source, pack, result = self._pack(root)
+            data = json.loads((pack / "character.json").read_text(encoding="utf-8"))
+            expected = hashlib.sha256(source.read_bytes()).hexdigest()
+            self.assertEqual(result["anchor_sha256"], expected)
+            self.assertEqual(data["anchor"]["sha256"], expected)
+            self.assertFalse(data["anchor"]["regeneration"])
+            self.assertTrue(data["claims"]["stable_character"])
+            self.assertFalse(data["claims"]["age_lineage"])
+            self.assertFalse(data["claims"]["production_promoted"])
+
+    def test_freeze_refuses_silent_replacement(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            other = root / "other.wav"
+            other.write_bytes(b"different")
+            with self.assertRaisesRegex(CharacterLabError, "silent replacement"):
+                freeze_character_identity("claire", other, pack)
+
+    def test_load_fails_closed_on_tampered_anchor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            (pack / "anchor.wav").write_bytes(b"tampered")
+            with self.assertRaisesRegex(CharacterLabError, "hash mismatch"):
+                load_character_identity(pack / "character.json")
+
+    def test_contract_rejects_unqualified_age_claim(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            spec = pack / "character.json"
+            data = json.loads(spec.read_text(encoding="utf-8"))
+            data["claims"]["age_lineage"] = True
+            spec.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaisesRegex(CharacterLabError, "age-lineage"):
+                load_character_identity(spec)
+
+    def test_render_builds_identity_once_and_is_deterministic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            provider = _FakeProvider()
+            lines = [
+                {"id": "panic", "text": "Sortez maintenant !"},
+                {"id": "calm", "text": "Je vais vous expliquer."},
+            ]
+            first = render_character_lines(pack / "character.json", lines, root / "out1", provider=provider)
+            seeds1 = [item["seed"] for item in first["rendered"]]
+            provider2 = _FakeProvider()
+            second = render_character_lines(pack / "character.json", lines, root / "out2", provider=provider2)
+            seeds2 = [item["seed"] for item in second["rendered"]]
+            self.assertEqual(first["status"], "success")
+            self.assertEqual(first["rendered_count"], 2)
+            self.assertEqual(provider.prompt_calls, 1)
+            self.assertEqual(provider2.prompt_calls, 1)
+            self.assertEqual(seeds1, seeds2)
+            self.assertTrue(first["anchor_verified_before_and_after"])
+            self.assertFalse(first["production_promoted"])
+
+    def test_line_failure_is_best_effort_without_recast(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            provider = _FakeProvider(fail_id="FAIL")
+            result = render_character_lines(
+                pack / "character.json",
+                [
+                    {"id": "one", "text": "Première ligne."},
+                    {"id": "two", "text": "FAIL"},
+                    {"id": "three", "text": "Troisième ligne."},
+                ],
+                root / "out",
+                provider=provider,
+            )
+            self.assertEqual(result["status"], "partial")
+            self.assertEqual(result["rendered_count"], 2)
+            self.assertEqual(result["failure_count"], 1)
+            self.assertEqual(provider.prompt_calls, 1)
+            self.assertEqual(len(provider.calls), 3)
+            self.assertEqual(result["provider"], "qwen3-xvector-lab")
+
+    def test_invalid_line_is_contract_error_not_silent_skip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            with self.assertRaisesRegex(CharacterLabError, "empty text"):
+                render_character_lines(
+                    pack / "character.json",
+                    [{"id": "bad", "text": ""}],
+                    root / "out",
+                    provider=_FakeProvider(),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_voice_character_lab.py
+++ b/tests/test_voice_character_lab.py
@@ -12,6 +12,10 @@ from audio_engine.voice_character_lab import (
 )
 
 
+def _wav_bytes(payload=b"approved-french-anchor"):
+    return b"RIFF" + (len(payload) + 4).to_bytes(4, "little") + b"WAVE" + payload
+
+
 class _FakeProvider:
     identity_mode = "x_vector_only"
 
@@ -42,7 +46,7 @@ class _UndeclaredModeProvider:
 class CharacterLabTests(unittest.TestCase):
     def _pack(self, root):
         source = root / "source.wav"
-        source.write_bytes(b"approved-french-anchor")
+        source.write_bytes(_wav_bytes())
         pack = root / "pack"
         result = freeze_character_identity(
             "claire",
@@ -62,16 +66,33 @@ class CharacterLabTests(unittest.TestCase):
             self.assertEqual(result["anchor_sha256"], expected)
             self.assertEqual(data["anchor"]["sha256"], expected)
             self.assertFalse(data["anchor"]["regeneration"])
+            self.assertEqual(data["language"], "French")
             self.assertTrue(data["claims"]["stable_character"])
             self.assertFalse(data["claims"]["age_lineage"])
             self.assertFalse(data["claims"]["production_promoted"])
+
+    def test_freeze_requires_real_wave_header(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bad = root / "bad.wav"
+            bad.write_bytes(b"not-a-wave")
+            with self.assertRaisesRegex(CharacterLabError, "RIFF/WAVE"):
+                freeze_character_identity("claire", bad, root / "pack")
+
+    def test_freeze_is_french_only_until_separately_qualified(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source.wav"
+            source.write_bytes(_wav_bytes())
+            with self.assertRaisesRegex(CharacterLabError, "French only"):
+                freeze_character_identity("claire", source, root / "pack", language="English")
 
     def test_freeze_refuses_silent_replacement(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             _, pack, _ = self._pack(root)
             other = root / "other.wav"
-            other.write_bytes(b"different")
+            other.write_bytes(_wav_bytes(b"different"))
             with self.assertRaisesRegex(CharacterLabError, "silent replacement"):
                 freeze_character_identity("claire", other, pack)
 
@@ -79,7 +100,7 @@ class CharacterLabTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             _, pack, _ = self._pack(root)
-            (pack / "anchor.wav").write_bytes(b"tampered")
+            (pack / "anchor.wav").write_bytes(_wav_bytes(b"tampered"))
             with self.assertRaisesRegex(CharacterLabError, "hash mismatch"):
                 load_character_identity(pack / "character.json")
 
@@ -88,7 +109,7 @@ class CharacterLabTests(unittest.TestCase):
             root = Path(tmp)
             _, pack, _ = self._pack(root)
             outside = root / "outside.wav"
-            outside.write_bytes(b"outside")
+            outside.write_bytes(_wav_bytes(b"outside"))
             spec = pack / "character.json"
             data = json.loads(spec.read_text(encoding="utf-8"))
             data["anchor"]["file"] = "../outside.wav"
@@ -105,7 +126,18 @@ class CharacterLabTests(unittest.TestCase):
             data = json.loads(spec.read_text(encoding="utf-8"))
             data["claims"]["age_lineage"] = True
             spec.write_text(json.dumps(data), encoding="utf-8")
-            with self.assertRaisesRegex(CharacterLabError, "age-lineage"):
+            with self.assertRaisesRegex(CharacterLabError, "age_lineage"):
+                load_character_identity(spec)
+
+    def test_contract_requires_explicit_non_production_claim(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            spec = pack / "character.json"
+            data = json.loads(spec.read_text(encoding="utf-8"))
+            del data["claims"]["production_promoted"]
+            spec.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaisesRegex(CharacterLabError, "production_promoted"):
                 load_character_identity(spec)
 
     def test_render_requires_explicit_xvector_mode(self):
@@ -118,6 +150,46 @@ class CharacterLabTests(unittest.TestCase):
                     [{"id": "one", "text": "Une ligne."}],
                     root / "out",
                     provider=_UndeclaredModeProvider(),
+                )
+
+    def test_render_rejects_language_switch_before_prompt_build(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            provider = _FakeProvider()
+            with self.assertRaisesRegex(CharacterLabError, "changes language"):
+                render_character_lines(
+                    pack / "character.json",
+                    [{"id": "one", "text": "Hello.", "language": "English"}],
+                    root / "out",
+                    provider=provider,
+                )
+            self.assertEqual(provider.prompt_calls, 0)
+
+    def test_render_rejects_duplicate_line_ids_before_prompt_build(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            provider = _FakeProvider()
+            with self.assertRaisesRegex(CharacterLabError, "duplicate line id"):
+                render_character_lines(
+                    pack / "character.json",
+                    [{"id": "same", "text": "Un."}, {"id": "same", "text": "Deux."}],
+                    root / "out",
+                    provider=provider,
+                )
+            self.assertEqual(provider.prompt_calls, 0)
+
+    def test_render_rejects_output_inside_character_pack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            with self.assertRaisesRegex(CharacterLabError, "outside the immutable character pack"):
+                render_character_lines(
+                    pack / "character.json",
+                    [{"id": "one", "text": "Une ligne."}],
+                    pack / "render",
+                    provider=_FakeProvider(),
                 )
 
     def test_render_builds_identity_once_and_is_deterministic(self):
@@ -163,18 +235,21 @@ class CharacterLabTests(unittest.TestCase):
             self.assertEqual(provider.prompt_calls, 1)
             self.assertEqual(len(provider.calls), 3)
             self.assertEqual(result["provider"], "qwen3-xvector-lab")
+            self.assertFalse((root / "out" / "clips" / "002--two.wav").exists())
 
-    def test_invalid_line_is_contract_error_not_silent_skip(self):
+    def test_invalid_line_is_contract_error_before_prompt_build(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             _, pack, _ = self._pack(root)
+            provider = _FakeProvider()
             with self.assertRaisesRegex(CharacterLabError, "empty text"):
                 render_character_lines(
                     pack / "character.json",
                     [{"id": "bad", "text": ""}],
                     root / "out",
-                    provider=_FakeProvider(),
+                    provider=provider,
                 )
+            self.assertEqual(provider.prompt_calls, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_voice_character_lab.py
+++ b/tests/test_voice_character_lab.py
@@ -31,6 +31,14 @@ class _FakeProvider:
         Path(path).write_bytes((segment["text"] + str(segment["seed"])).encode())
 
 
+class _UndeclaredModeProvider:
+    def build_identity_prompt(self, anchor):
+        return {"anchor": Path(anchor).name}
+
+    def synthesize(self, segment, path, *, voice_clone_prompt):
+        Path(path).write_bytes(b"should-not-render")
+
+
 class CharacterLabTests(unittest.TestCase):
     def _pack(self, root):
         source = root / "source.wav"
@@ -75,6 +83,20 @@ class CharacterLabTests(unittest.TestCase):
             with self.assertRaisesRegex(CharacterLabError, "hash mismatch"):
                 load_character_identity(pack / "character.json")
 
+    def test_contract_rejects_anchor_path_escape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            outside = root / "outside.wav"
+            outside.write_bytes(b"outside")
+            spec = pack / "character.json"
+            data = json.loads(spec.read_text(encoding="utf-8"))
+            data["anchor"]["file"] = "../outside.wav"
+            data["anchor"]["sha256"] = hashlib.sha256(outside.read_bytes()).hexdigest()
+            spec.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaisesRegex(CharacterLabError, "inside the character pack"):
+                load_character_identity(spec)
+
     def test_contract_rejects_unqualified_age_claim(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -85,6 +107,18 @@ class CharacterLabTests(unittest.TestCase):
             spec.write_text(json.dumps(data), encoding="utf-8")
             with self.assertRaisesRegex(CharacterLabError, "age-lineage"):
                 load_character_identity(spec)
+
+    def test_render_requires_explicit_xvector_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, pack, _ = self._pack(root)
+            with self.assertRaisesRegex(CharacterLabError, "explicitly use x_vector_only"):
+                render_character_lines(
+                    pack / "character.json",
+                    [{"id": "one", "text": "Une ligne."}],
+                    root / "out",
+                    provider=_UndeclaredModeProvider(),
+                )
 
     def test_render_builds_identity_once_and_is_deterministic(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Scope

Experimental Voice Casting Lab integration only. Production render path remains untouched.

Implements the minimal post-qualification contract after Qwen3 x-vector human PASS:

- frozen character pack = `character_id` + copied anchor + SHA-256 + `x_vector_only` mode;
- hard failure before model load if the anchor hash differs;
- no anchor regeneration and no silent replacement;
- reusable Qwen3 x-vector identity prompt built once per character render;
- deterministic per-line seeds;
- line synthesis is best-effort (`partial` manifest) so one residual line failure does not discard successful lines;
- anchor hash is checked again after rendering;
- explicit `production_promoted=false` and `age_lineage=false`.

Evidence boundary:

- issue #63: x-vector killer 4/4 acting, 4/4 French, 3/4 identity -> BORDERLINE;
- issue #65: predeclared narrow confirmation PASS 2/2 identity, French good on both;
- no production promotion authorized;
- no age-lineage claim.

Do not merge until CI is green and the diff remains isolated from the production render path.