### PR TITLE
INFRA: publish Voice Lab listening tests with GitHub Pages

### DIFF
--- a/.github/workflows/voice-lab-pages.yml
+++ b/.github/workflows/voice-lab-pages.yml
@@ -1,0 +1,117 @@
+name: Voice Lab Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - voice-lab-pages/request.json
+      - .github/workflows/voice-lab-pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: voice-lab-pages
+  cancel-in-progress: true
+
+jobs:
+  request:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.request.outputs.enabled }}
+      run_id: ${{ steps.request.outputs.run_id }}
+      artifact: ${{ steps.request.outputs.artifact }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: request
+        name: Validate publication request
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f voice-lab-pages/request.json
+          ENABLED="$(jq -r '.enabled // false' voice-lab-pages/request.json)"
+          echo "enabled=$ENABLED" >> "$GITHUB_OUTPUT"
+          if [ "$ENABLED" != "true" ]; then
+            echo "Voice Lab Pages publication is disabled."
+            echo "run_id=" >> "$GITHUB_OUTPUT"
+            echo "artifact=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          RUN_ID="$(jq -r '.run_id' voice-lab-pages/request.json)"
+          ARTIFACT="$(jq -r '.artifact' voice-lab-pages/request.json)"
+          [[ "$RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$ARTIFACT" =~ ^voice-casting-[a-zA-Z0-9._-]+$ ]]
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: request
+    if: needs.request.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify source run and download exact artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ needs.request.outputs.run_id }}
+          ARTIFACT: ${{ needs.request.outputs.artifact }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          RUN_JSON="$(gh api "repos/$REPO/actions/runs/$RUN_ID")"
+          test "$(jq -r '.repository.full_name' <<<"$RUN_JSON")" = "$REPO"
+          test "$(jq -r '.conclusion' <<<"$RUN_JSON")" = "success"
+          HEAD_SHA="$(jq -r '.head_sha' <<<"$RUN_JSON")"
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          mkdir -p _download
+          gh run download "$RUN_ID" --repo "$REPO" -n "$ARTIFACT" -D _download
+          test -f _download/index.html
+          printf '%s\n' "$RUN_JSON" > _download/source-run.json
+
+      - name: Build minimal public listening site
+        env:
+          RUN_ID: ${{ needs.request.outputs.run_id }}
+          ARTIFACT: ${{ needs.request.outputs.artifact }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p _site/lab/current
+          cp -R _download/. _site/lab/current/
+          python - <<'PY'
+          from pathlib import Path
+          p = Path('_site/lab/current/index.html')
+          text = p.read_text(encoding='utf-8')
+          marker = '<meta name="robots" content="noindex,nofollow">'
+          if marker not in text:
+              text = text.replace('</head>', marker + '</head>', 1)
+          p.write_text(text, encoding='utf-8')
+          PY
+          cat > _site/index.html <<'HTML'
+          <!doctype html><html lang="fr"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Voice Casting Lab</title><style>body{font-family:system-ui,sans-serif;max-width:720px;margin:12vh auto;padding:0 24px;line-height:1.5}a{display:inline-block;padding:14px 18px;border:1px solid #222;border-radius:10px;color:inherit;text-decoration:none;font-weight:650}</style></head><body><h1>Voice Casting Lab</h1><p>Le test humain courant est prêt.</p><a href="lab/current/">Ouvrir le test</a></body></html>
+          HTML
+          cat > _site/lab/current/publication.json <<EOF
+          {"schema":"voice-lab-pages-publication-v1","run_id":"$RUN_ID","artifact":"$ARTIFACT"}
+          EOF
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/voice-lab-pages/README.md
+++ b/voice-lab-pages/README.md
@@ -1,0 +1,20 @@
+# Voice Lab Pages
+
+GitHub Pages is only the human listening surface for Voice Casting Lab.
+
+Source of truth remains the successful GitHub Actions artifact referenced by `request.json`.
+
+Rules:
+
+- publisher workflow lives on `main`;
+- publication request must point to one successful run in this repository;
+- artifact name must start with `voice-casting-`;
+- the artifact must contain `index.html`;
+- Pages publishes only the current listening bundle;
+- generated audio is not committed to the source repository;
+- Pages is public, so do not publish confidential/proprietary anchors or media;
+- published pages get `noindex,nofollow` as a courtesy, not an access-control mechanism;
+- human results continue to export locally as JSON;
+- Pages publication is not production promotion and has no effect on the production renderer.
+
+`request.json` stays disabled between tests. After a technical PASS, update it to the exact run id and artifact name. The trusted `main` workflow validates and deploys that artifact.

--- a/voice-lab-pages/request.json
+++ b/voice-lab-pages/request.json
@@ -1,0 +1,5 @@
+{
+  "enabled": false,
+  "run_id": null,
+  "artifact": null
+}


### PR DESCRIPTION
Adds a trusted main-branch GitHub Pages publisher for Voice Casting Lab listening bundles.

Principles:
- Pages is only the human listening surface; Actions artifacts remain canonical evidence.
- Publication is driven by an exact `run_id` + `voice-casting-*` artifact request.
- Source run must belong to this repository and have conclusion `success`.
- Generated media is never committed to the source repository.
- Published test is `/lab/current/`; no historical site archive is maintained (Actions already provides immutable run evidence).
- `noindex,nofollow` is injected, but Pages is still public and must not host confidential assets.
- Results still export locally as JSON.
- No production renderer or voice logic changes.

The request is disabled by default. Future technical-PASS tests can be published by changing only `voice-lab-pages/request.json` on main.