### PR TITLE
INFRA: trigger Voice Lab Pages publication

### DIFF
--- a/voice-lab-pages/request.json
+++ b/voice-lab-pages/request.json
@@ -1,5 +1,6 @@
 {
   "enabled": true,
   "run_id": 32813525803,
-  "artifact": "voice-casting-qwen3-style-transplant-killer-recovery"
+  "artifact": "voice-casting-qwen3-style-transplant-killer-recovery",
+  "requested_at": "2026-08-25T08:02:00+02:00"
 }


### PR DESCRIPTION
Triggers the already-approved Voice Lab Pages publisher for the exact successful recovery bundle.

- source run: 32813525803
- artifact: voice-casting-qwen3-style-transplant-killer-recovery
- no production audio code changes
- request semantics unchanged; adds only a request timestamp so the merge creates the required push event on main