### PR TITLE
INFRA: publish OpenVoice V2 tone killer on Pages

### DIFF
--- a/voice-lab-pages/request.json
+++ b/voice-lab-pages/request.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "run_id": 32813525803,
-  "artifact": "voice-casting-qwen3-style-transplant-killer-recovery",
-  "requested_at": "2026-08-25T08:02:00+02:00"
+  "run_id": 32817107201,
+  "artifact": "voice-casting-openvoice-v2-tone-killer",
+  "requested_at": "2026-08-25T08:34:00+02:00"
 }


### PR DESCRIPTION
Updates only the trusted Voice Lab Pages publication pointer.

- source run: `32817107201`
- artifact: `voice-casting-openvoice-v2-tone-killer`
- source technical gate: PASS
- no audio generation
- no production renderer changes
- PR #76 remains unmerged pending human artistic gate