### PR TITLE
LAB: efficient contrasted Qwen3 casting — HUMAN PASS

### DIFF
--- a/.github/workflows/voice-casting-qwen3-contrast-casting.yml
+++ b/.github/workflows/voice-casting-qwen3-contrast-casting.yml
@@ -1,0 +1,268 @@
+name: Voice Casting Qwen3 Contrast Casting
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - src/audio_engine/voice_lab_qwen3_contrast_casting.py
+      - tests/test_voice_lab_qwen3_contrast_casting.py
+      - .github/workflows/voice-casting-qwen3-contrast-casting.yml
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+env:
+  QWEN_REV: 022e286b98fbec7e1e916cb940cdf532cd9f488e
+  VD_MODEL_ID: Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign
+  VD_MODEL_REV: 5ecdb67327fd37bb2e042aab12ff7391903235d3
+  BASE_MODEL_ID: Qwen/Qwen3-TTS-12Hz-1.7B-Base
+  BASE_MODEL_REV: 74a6279626edc2d5a787d5b6467668eba0b86ef6
+  BASELINE_RUN_ID: "32772435007"
+  BASELINE_ARTIFACT: voice-casting-qwen3-xvector-identity-confirm
+  TOKENIZERS_PARALLELISM: "false"
+  OMP_NUM_THREADS: "2"
+  MKL_NUM_THREADS: "2"
+  HF_HUB_DISABLE_TELEMETRY: "1"
+  PIP_NO_CACHE_DIR: "1"
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Run offline gates
+        run: |
+          python -m pip install --disable-pip-version-check -e .
+          python -m unittest tests.test_voice_lab_qwen3_contrast_casting -v
+      - name: Publish run locator
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo "${{ github.repository }}" \
+            --title "Qwen3 contrast casting running $GITHUB_RUN_ID" \
+            --body "Efficient contrasted-casting experiment started.\n\n- run_id: $GITHUB_RUN_ID\n- architecture: 4 VoiceDesign anchors -> cheap acoustic gate vs known-confusable Claire/Lucie -> only then 2 neutral x-vector lines per selected voice\n- no emotion rendering before identity gate\n- final artifact if qualified: voice-casting-qwen3-contrast-casting\n\nExplicit recast experiment only. Production Edge unchanged."
+
+  anchors:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        role: [claire, lucie]
+    env:
+      ROLE: ${{ matrix.role }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Free runner disk
+        run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+      - name: Install core engine
+        run: python -m pip install --disable-pip-version-check -e .
+      - name: Checkout pinned Qwen3 source
+        run: |
+          git clone --filter=blob:none https://github.com/QwenLM/Qwen3-TTS.git qwen3-upstream
+          cd qwen3-upstream
+          git checkout "$QWEN_REV"
+          test "$(git rev-parse HEAD)" = "$QWEN_REV"
+      - name: Install isolated CPU inference stack
+        run: |
+          python -m pip install --disable-pip-version-check --index-url https://download.pytorch.org/whl/cpu torch torchaudio
+          python -m pip install --disable-pip-version-check -e ./qwen3-upstream
+          python -m pip check
+      - name: Download pinned VoiceDesign model
+        run: |
+          python - <<'PY'
+          import os
+          from huggingface_hub import snapshot_download
+          print(snapshot_download(repo_id=os.environ['VD_MODEL_ID'], revision=os.environ['VD_MODEL_REV'], local_dir='qwen3-vd-model'))
+          PY
+          test -f qwen3-vd-model/model.safetensors
+      - name: Generate two neutral anchor candidates
+        run: |
+          python - <<'PY'
+          import os, random, time
+          from pathlib import Path
+          import numpy as np
+          import soundfile as sf
+          import torch
+          from qwen_tts import Qwen3TTSModel
+          from transformers.utils import logging as transformers_logging
+          from audio_engine.voice_lab_qwen3_contrast_casting import ANCHOR_TEXT, CANDIDATES
+
+          role = os.environ['ROLE']
+          selected = [(cid, spec) for cid, spec in CANDIDATES.items() if spec['role'] == role]
+          assert len(selected) == 2
+          model = Qwen3TTSModel.from_pretrained('qwen3-vd-model', device_map='cpu', dtype=torch.bfloat16, attn_implementation='eager')
+          transformers_logging.disable_progress_bar()
+          out = Path('anchors'); out.mkdir()
+          for index, (cid, spec) in enumerate(selected, 1):
+              seed = int(spec['seed'])
+              random.seed(seed); np.random.seed(seed); torch.manual_seed(seed)
+              started = time.monotonic()
+              print(f"START {role} {index}/2 {cid}", flush=True)
+              wavs, sr = model.generate_voice_design(
+                  text=ANCHOR_TEXT,
+                  instruct=spec['instruct'],
+                  language='French',
+                  non_streaming_mode=True,
+                  do_sample=True,
+                  max_new_tokens=512,
+              )
+              sf.write(out / f'{cid}.wav', wavs[0], sr)
+              print(f"SUCCESS {cid} {time.monotonic()-started:.1f}s", flush=True)
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: qwen3-contrast-anchors-${{ matrix.role }}
+          path: anchors/
+          if-no-files-found: error
+          retention-days: 14
+
+  select:
+    needs: anchors
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install core engine
+        run: python -m pip install --disable-pip-version-check -e .
+      - name: Download candidate anchors
+        uses: actions/download-artifact@v4
+        with:
+          pattern: qwen3-contrast-anchors-*
+          path: candidate-anchors
+      - name: Download exact known-confusable baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run download "$BASELINE_RUN_ID" --repo "${{ github.repository }}" -n "$BASELINE_ARTIFACT" -D baseline
+          sha256sum baseline/reference-*-qwen3.wav
+      - name: Select only if materially farther apart than baseline
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from audio_engine.voice_lab_qwen3_contrast_casting import select_pair
+          result = select_pair(Path('candidate-anchors'), Path('baseline'), Path('selected-pair'))
+          print(json.dumps({
+              'status': result['status'],
+              'selected': result['selected'],
+              'all_pairs': result['comparisons'],
+          }, ensure_ascii=False, indent=2))
+          if result['status'] != 'selected':
+              raise SystemExit('No candidate pair beat the known-confusable baseline strongly enough; stop before Base model.')
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: qwen3-contrast-selected-pair
+          path: selected-pair/
+          if-no-files-found: error
+          retention-days: 14
+
+  identity:
+    needs: select
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        role: [claire, lucie]
+    env:
+      ROLE: ${{ matrix.role }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Free runner disk
+        run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+      - name: Install core engine
+        run: python -m pip install --disable-pip-version-check -e .
+      - uses: actions/download-artifact@v4
+        with:
+          name: qwen3-contrast-selected-pair
+          path: selected-pair
+      - name: Checkout pinned Qwen3 source
+        run: |
+          git clone --filter=blob:none https://github.com/QwenLM/Qwen3-TTS.git qwen3-upstream
+          cd qwen3-upstream
+          git checkout "$QWEN_REV"
+          test "$(git rev-parse HEAD)" = "$QWEN_REV"
+      - name: Install isolated CPU inference stack
+        run: |
+          python -m pip install --disable-pip-version-check --index-url https://download.pytorch.org/whl/cpu torch torchaudio
+          python -m pip install --disable-pip-version-check -e ./qwen3-upstream
+          python -m pip check
+      - name: Download pinned Base model
+        run: |
+          python - <<'PY'
+          import os
+          from huggingface_hub import snapshot_download
+          print(snapshot_download(repo_id=os.environ['BASE_MODEL_ID'], revision=os.environ['BASE_MODEL_REV'], local_dir='qwen3-base-model'))
+          PY
+          test -f qwen3-base-model/model.safetensors
+      - name: Render only two neutral identity lines
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          from audio_engine.voice_lab_qwen3_contrast_casting import render_identity_check
+          result = render_identity_check(os.environ['ROLE'], Path('selected-pair'), Path('identity-output'), model_dir=Path('qwen3-base-model'))
+          print(json.dumps(result, ensure_ascii=False, indent=2))
+          if result['status'] != 'success' or result['rendered_count'] != 2:
+              raise SystemExit(1)
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: qwen3-contrast-identity-${{ matrix.role }}
+          path: identity-output/
+          if-no-files-found: error
+          retention-days: 14
+
+  bundle:
+    needs: identity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install core engine
+        run: python -m pip install --disable-pip-version-check -e .
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: qwen3-contrast-identity-*
+          path: identity-inputs
+      - name: Assemble two-screen blind identity gate
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from audio_engine.voice_lab_qwen3_contrast_casting import assemble_bundle
+          result = assemble_bundle(Path('identity-inputs'), Path('bundle'))
+          print(json.dumps({'status': result['status'], 'trial_count': result['trial_count'], 'decision': result['decision']}, ensure_ascii=False, indent=2))
+          if result['status'] != 'success' or result['trial_count'] != 2:
+              raise SystemExit(1)
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: voice-casting-qwen3-contrast-casting
+          path: bundle/
+          if-no-files-found: error
+          retention-days: 14

--- a/src/audio_engine/voice_lab_qwen3_contrast_casting.py
+++ b/src/audio_engine/voice_lab_qwen3_contrast_casting.py
@@ -1,0 +1,338 @@
+"""Efficient contrasted-casting experiment for Voice Casting Lab.
+
+Four neutral VoiceDesign anchors are screened acoustically against the known-confusable
+Claire/Lucie baseline. Only the most separated cross-role pair may proceed to a tiny
+Qwen3 Base x-vector identity check. This is an explicit recast experiment; it never
+silently replaces the qualified Claire/Lucie anchors.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import shutil
+from pathlib import Path
+
+from .providers.qwen3_xvector_lab import Qwen3XVectorLabProvider
+from .voice_casting_distance import contrast_gate
+
+QWEN_REVISION = "022e286b98fbec7e1e916cb940cdf532cd9f488e"
+VOICE_DESIGN_MODEL_ID = "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
+VOICE_DESIGN_MODEL_REVISION = "5ecdb67327fd37bb2e042aab12ff7391903235d3"
+BASE_MODEL_ID = "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+BASE_MODEL_REVISION = "74a6279626edc2d5a787d5b6467668eba0b86ef6"
+BASELINE_RUN_ID = 32772435007
+BASELINE_ARTIFACT = "voice-casting-qwen3-xvector-identity-confirm"
+BLIND_SEED = 2026082509
+
+BASELINE = {
+    "claire": {
+        "file": "reference-claire-qwen3.wav",
+        "sha256": "1012fdc137a848e71a9403140267e62140ad87b14ee9a3236e106b57775afa55",
+    },
+    "lucie": {
+        "file": "reference-lucie-qwen3.wav",
+        "sha256": "f42c27ce633e0d009a95079cdfddc605772bbf48e9806fba6fba3749e5aa1ee2",
+    },
+}
+
+ANCHOR_TEXT = (
+    "La lumière traverse les volets. Je suis ici depuis l'aube, "
+    "et je peux enfin vous raconter ce qui s'est passé."
+)
+
+CANDIDATES = {
+    "claire-a": {
+        "role": "claire",
+        "seed": 2026082511,
+        "instruct": (
+            "Femme française d'environ 52 ans. Contralto bas, chaud et mat, forte résonance "
+            "de poitrine, léger grain velouté, consonnes posées, débit calme et mesuré, "
+            "autorité tranquille. Voix naturelle, sans caricature."
+        ),
+    },
+    "claire-b": {
+        "role": "claire",
+        "seed": 2026082512,
+        "instruct": (
+            "Femme française d'environ 46 ans. Voix grave de mezzo-contralto, sombre et boisée, "
+            "résonance ample, attaque douce, articulation lente et précise, légère rugosité "
+            "naturelle, présence stable."
+        ),
+    },
+    "lucie-a": {
+        "role": "lucie",
+        "seed": 2026082521,
+        "instruct": (
+            "Jeune femme française d'environ 24 ans. Voix claire et haute, légère mais naturelle, "
+            "résonance brillante en avant, très peu de grain, articulation vive et nette, débit "
+            "plus rapide, énergie lumineuse."
+        ),
+    },
+    "lucie-b": {
+        "role": "lucie",
+        "seed": 2026082522,
+        "instruct": (
+            "Femme française d'environ 29 ans. Voix mezzo claire, légère et aérienne, timbre "
+            "lumineux, résonance tête et avant, consonnes rapides, intonation mobile, sourire "
+            "discret, aucune gravité sombre."
+        ),
+    },
+}
+
+IDENTITY_LINES = (
+    {
+        "id": "neutral-one",
+        "text": "Nous partirons après le lever du jour. D'ici là, restez près de la fenêtre.",
+    },
+    {
+        "id": "neutral-two",
+        "text": "J'ai retrouvé la lettre dans le tiroir. Personne ne l'avait ouverte depuis des années.",
+    },
+)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def experiment_spec():
+    return {
+        "schema": "qwen3-contrast-casting-v1",
+        "recast_experiment": True,
+        "production_promotion": False,
+        "age_lineage": False,
+        "qwen_revision": QWEN_REVISION,
+        "voice_design_model": {
+            "id": VOICE_DESIGN_MODEL_ID,
+            "revision": VOICE_DESIGN_MODEL_REVISION,
+        },
+        "base_model": {"id": BASE_MODEL_ID, "revision": BASE_MODEL_REVISION},
+        "baseline_run_id": BASELINE_RUN_ID,
+        "baseline_artifact": BASELINE_ARTIFACT,
+        "anchor_text": ANCHOR_TEXT,
+        "candidates": {key: dict(value) for key, value in CANDIDATES.items()},
+        "identity_lines": [dict(line) for line in IDENTITY_LINES],
+        "gates": {
+            "acoustic_prefilter": "candidate >= 1.35x baseline and >= baseline + 8 points",
+            "human_identity": "2/2 blind mappings correct",
+            "human_french": "both-good on both screens",
+            "no_emotion_before_identity_pass": True,
+        },
+    }
+
+
+def select_pair(candidate_root, baseline_root, output_dir):
+    candidate_root = Path(candidate_root)
+    baseline_root = Path(baseline_root)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    baseline_paths = {}
+    for role, item in BASELINE.items():
+        path = baseline_root / item["file"]
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        actual = _sha256(path)
+        if actual != item["sha256"]:
+            raise ValueError(f"baseline hash mismatch for {role}: {actual}")
+        baseline_paths[role] = path
+
+    candidate_paths = {}
+    for candidate_id in CANDIDATES:
+        matches = list(candidate_root.rglob(f"{candidate_id}.wav"))
+        if len(matches) != 1:
+            raise ValueError(f"expected one anchor for {candidate_id}, got {len(matches)}")
+        candidate_paths[candidate_id] = matches[0]
+
+    comparisons = []
+    for claire_id, claire_spec in CANDIDATES.items():
+        if claire_spec["role"] != "claire":
+            continue
+        for lucie_id, lucie_spec in CANDIDATES.items():
+            if lucie_spec["role"] != "lucie":
+                continue
+            gate = contrast_gate(
+                candidate_paths[claire_id],
+                candidate_paths[lucie_id],
+                baseline_paths["claire"],
+                baseline_paths["lucie"],
+            )
+            comparisons.append(
+                {
+                    "claire_id": claire_id,
+                    "lucie_id": lucie_id,
+                    "eligible": gate["eligible"],
+                    "candidate_score": gate["candidate_score"],
+                    "baseline_score": gate["baseline_score"],
+                    "required_score": gate["required_score"],
+                    "components": gate["candidate"]["components"],
+                }
+            )
+
+    winner = max(comparisons, key=lambda item: item["candidate_score"])
+    result = {
+        **experiment_spec(),
+        "status": "selected" if winner["eligible"] else "rejected",
+        "comparisons": comparisons,
+        "selected": winner,
+        "claim": "acoustic-prefilter-only",
+    }
+    if winner["eligible"]:
+        selected_claire = candidate_paths[winner["claire_id"]]
+        selected_lucie = candidate_paths[winner["lucie_id"]]
+        shutil.copy2(selected_claire, output_dir / "reference-claire.wav")
+        shutil.copy2(selected_lucie, output_dir / "reference-lucie.wav")
+        result["selected_anchor_sha256"] = {
+            "claire": _sha256(output_dir / "reference-claire.wav"),
+            "lucie": _sha256(output_dir / "reference-lucie.wav"),
+        }
+    (output_dir / "selection.json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return result
+
+
+def render_identity_check(role, selection_dir, output_dir, *, provider=None, model_dir=None):
+    if role not in {"claire", "lucie"}:
+        raise ValueError(f"unknown role: {role}")
+    selection_dir = Path(selection_dir)
+    selection = json.loads((selection_dir / "selection.json").read_text(encoding="utf-8"))
+    if selection.get("status") != "selected":
+        raise ValueError("contrast casting did not pass the acoustic prefilter")
+    anchor = selection_dir / f"reference-{role}.wav"
+    expected = selection["selected_anchor_sha256"][role]
+    if _sha256(anchor) != expected:
+        raise ValueError(f"selected {role} anchor hash mismatch")
+    if provider is None:
+        if model_dir is None:
+            raise ValueError("model_dir is required when provider is not injected")
+        provider = Qwen3XVectorLabProvider(model_dir=model_dir, device="cpu")
+    if getattr(provider, "identity_mode", None) != "x_vector_only":
+        raise ValueError("identity check requires x_vector_only provider")
+
+    prompt = provider.build_identity_prompt(anchor)
+    output_dir = Path(output_dir)
+    clips = output_dir / "clips"
+    clips.mkdir(parents=True, exist_ok=True)
+    rendered = []
+    for index, line in enumerate(IDENTITY_LINES, 1):
+        out = clips / f"{line['id']}.wav"
+        seed_payload = f"contrast-casting\0{role}\0{line['id']}".encode("utf-8")
+        seed = int.from_bytes(hashlib.sha256(seed_payload).digest()[:4], "big")
+        provider.synthesize(
+            {"text": line["text"], "language": "French", "seed": seed},
+            out,
+            voice_clone_prompt=prompt,
+        )
+        rendered.append({"id": line["id"], "file": f"clips/{line['id']}.wav", "seed": seed})
+    shutil.copy2(anchor, output_dir / "reference.wav")
+    result = {
+        "schema": "qwen3-contrast-casting-character-v1",
+        "status": "success",
+        "role": role,
+        "anchor_sha256": expected,
+        "rendered_count": len(rendered),
+        "rendered": rendered,
+    }
+    (output_dir / "character-result.json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return result
+
+
+def _role_root(root: Path, role: str):
+    matches = []
+    for path in Path(root).rglob("character-result.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("role") == role:
+            matches.append(path.parent)
+    if len(matches) != 1:
+        raise ValueError(f"expected one identity result for {role}, got {len(matches)}")
+    return matches[0]
+
+
+def assemble_bundle(input_root, output_dir, *, seed=BLIND_SEED):
+    input_root = Path(input_root)
+    output_dir = Path(output_dir)
+    clips_dir = output_dir / "clips"
+    clips_dir.mkdir(parents=True, exist_ok=True)
+    roots = {role: _role_root(input_root, role) for role in ("claire", "lucie")}
+
+    references = {}
+    rendered = {}
+    hashes = {}
+    for role, root in roots.items():
+        result = json.loads((root / "character-result.json").read_text(encoding="utf-8"))
+        if result.get("status") != "success" or result.get("rendered_count") != len(IDENTITY_LINES):
+            raise ValueError(f"incomplete identity render for {role}")
+        ref_name = f"reference-{role}.wav"
+        shutil.copy2(root / "reference.wav", output_dir / ref_name)
+        references[role] = ref_name
+        hashes[role] = result["anchor_sha256"]
+        for item in result["rendered"]:
+            name = f"{role}--{item['id']}.wav"
+            shutil.copy2(root / item["file"], clips_dir / name)
+            rendered[(role, item["id"])] = f"clips/{name}"
+
+    rnd = random.Random(seed)
+    trials = []
+    for line in IDENTITY_LINES:
+        options = [
+            {"role": role, "file": rendered[(role, line["id"])]}
+            for role in ("claire", "lucie")
+        ]
+        rnd.shuffle(options)
+        trials.append(
+            {
+                "id": line["id"],
+                "text": line["text"],
+                "references": [
+                    {"role": "claire", "label": "Référence 1", "file": references["claire"]},
+                    {"role": "lucie", "label": "Référence 2", "file": references["lucie"]},
+                ],
+                "options": [
+                    {"letter": letter, **option} for letter, option in zip("AB", options)
+                ],
+                "correct_reference_for_A": "Référence 1" if options[0]["role"] == "claire" else "Référence 2",
+            }
+        )
+
+    manifest = {
+        "schema": "qwen3-contrast-casting-identity-v1",
+        "status": "success",
+        "trial_count": len(trials),
+        "anchor_sha256": hashes,
+        "decision": {
+            "identity_pass": "2/2 pair mappings correct",
+            "french_pass": "both-good on both screens",
+            "emotion_test": False,
+            "production_promotion": False,
+        },
+        "trials": trials,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    _write_player(output_dir, trials)
+    return manifest
+
+
+def _write_player(output_dir: Path, trials):
+    public = [
+        {
+            "id": trial["id"],
+            "text": trial["text"],
+            "references": trial["references"],
+            "options": [{"letter": o["letter"], "file": o["file"]} for o in trial["options"]],
+        }
+        for trial in trials
+    ]
+    public_json = json.dumps(public, ensure_ascii=False).replace("</", "<\\/")
+    mapping_json = json.dumps({"trials": trials}, ensure_ascii=False).replace("</", "<\\/")
+    html = f'''<!doctype html><html lang="fr"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Contraste personnages</title><style>body{{font-family:system-ui,sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem}}.grid{{display:grid;grid-template-columns:1fr 1fr;gap:1rem}}.card{{border:1px solid #999;border-radius:12px;padding:1rem}}audio{{width:100%}}label{{display:block;margin:.6rem 0}}button{{padding:.7rem 1rem;margin:.4rem}}@media(max-width:650px){{.grid{{grid-template-columns:1fr}}}}</style></head><body><h1>Test de contraste des personnages</h1><p>2 écrans seulement. Identifiez la voix de A puis vérifiez le français.</p><p id="progress"></p><div id="app"></div><button id="back">Précédent</button><button id="next">Suivant</button><button id="export">Exporter le JSON</button><script>const trials={public_json};const mapping={mapping_json};const KEY='qwen3-contrast-casting-identity-v1';let state={{index:0,responses:{{}}}};try{{state=JSON.parse(localStorage.getItem(KEY))||state}}catch(e){{}}function save(){{try{{localStorage.setItem(KEY,JSON.stringify(state))}}catch(e){{}}}}function chosen(n){{const x=document.querySelector('input[name="'+n+'"]:checked');return x?x.value:null}}function render(){{const t=trials[state.index];document.getElementById('progress').textContent='Écran '+(state.index+1)+'/'+trials.length;const refs=t.references.map(r=>`<div><h3>${{r.label}}</h3><audio controls src="${{r.file}}"></audio></div>`).join('');const opts=t.options.map(o=>`<div><h3>Candidat ${{o.letter}}</h3><audio controls src="${{o.file}}"></audio></div>`).join('');document.getElementById('app').innerHTML=`<div class="card"><p><em>${{t.text}}</em></p><h2>Références</h2><div class="grid">${{refs}}</div><h2>Candidats</h2><div class="grid">${{opts}}</div><fieldset><legend>À quelle référence correspond A ?</legend><label><input type=radio name=identity value="Référence 1"> Référence 1</label><label><input type=radio name=identity value="Référence 2"> Référence 2</label><label><input type=radio name=identity value=uncertain> Impossible à distinguer</label></fieldset><fieldset><legend>Français</legend><label><input type=radio name=french value=both-good> Les deux corrects/naturels</label><label><input type=radio name=french value=bad-A> Défaut éliminatoire A</label><label><input type=radio name=french value=bad-B> Défaut éliminatoire B</label><label><input type=radio name=french value=bad-both> Défaut éliminatoire sur les deux</label></fieldset></div>`;const old=state.responses[t.id];if(old){{for(const [n,v] of Object.entries({{identity:old.identity,french:old.french}})){{const e=document.querySelector(`input[name="${{n}}"][value="${{v}}"]`);if(e)e.checked=true}}}}}}function commit(){{const t=trials[state.index],r={{identity:chosen('identity'),french:chosen('french')}};if(Object.values(r).some(v=>!v))return false;state.responses[t.id]=r;save();return true}}document.getElementById('next').onclick=()=>{{if(!commit())return alert('Répondez aux deux questions.');if(state.index<trials.length-1)state.index++;render()}};document.getElementById('back').onclick=()=>{{commit();if(state.index>0)state.index--;render()}};document.getElementById('export').onclick=()=>{{if(!commit())return alert('Répondez aux deux questions.');if(Object.keys(state.responses).length!==trials.length)return alert('Complétez les deux écrans.');const out={{schema:KEY,exported_at:new Date().toISOString(),responses:state.responses,mapping:mapping}};const blob=new Blob([JSON.stringify(out,null,2)],{{type:'application/json'}});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='qwen3-contrast-casting-results.json';a.click();URL.revokeObjectURL(a.href)}};render();</script></body></html>'''
+    (output_dir / "index.html").write_text(html, encoding="utf-8")

--- a/tests/test_voice_lab_qwen3_contrast_casting.py
+++ b/tests/test_voice_lab_qwen3_contrast_casting.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import math
+import struct
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+
+from audio_engine.voice_lab_qwen3_contrast_casting import (
+    BASELINE,
+    CANDIDATES,
+    IDENTITY_LINES,
+    assemble_bundle,
+    render_identity_check,
+    select_pair,
+)
+
+
+def _write_voice(path, *, f0, seconds=1.4, harmonics=(1.0, 0.4, 0.2), sr=24000):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    norm = sum(abs(value) for value in harmonics)
+    values = []
+    for index in range(int(sr * seconds)):
+        t = index / sr
+        signal = sum(
+            weight * math.sin(2 * math.pi * f0 * harmonic * t)
+            for harmonic, weight in enumerate(harmonics, 1)
+        )
+        signal *= 0.5 / norm
+        values.append(int(max(-0.99, min(0.99, signal)) * 32767))
+    with wave.open(str(path), "wb") as stream:
+        stream.setnchannels(1)
+        stream.setsampwidth(2)
+        stream.setframerate(sr)
+        stream.writeframes(struct.pack(f"<{len(values)}h", *values))
+
+
+def _sha256(path):
+    import hashlib
+
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+class FakeProvider:
+    identity_mode = "x_vector_only"
+
+    def __init__(self):
+        self.prompts = 0
+
+    def build_identity_prompt(self, anchor):
+        self.prompts += 1
+        return Path(anchor)
+
+    def synthesize(self, segment, path, *, voice_clone_prompt):
+        # The exact audio is irrelevant for contract tests; preserve role-dependent pitch.
+        pitch = 145 if "claire" in str(voice_clone_prompt) else 270
+        _write_voice(path, f0=pitch, seconds=0.8)
+
+
+class ContrastCastingTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def _prepare(self):
+        baseline = self.root / "baseline"
+        candidates = self.root / "candidates"
+        _write_voice(baseline / BASELINE["claire"]["file"], f0=180)
+        _write_voice(baseline / BASELINE["lucie"]["file"], f0=190)
+        # Test fixtures need matching hashes, so patch the in-memory spec only for this test.
+        old_hashes = {role: BASELINE[role]["sha256"] for role in BASELINE}
+        for role in BASELINE:
+            BASELINE[role]["sha256"] = _sha256(baseline / BASELINE[role]["file"])
+        _write_voice(candidates / "claire-a.wav", f0=145, seconds=1.6, harmonics=(1.0, 0.55, 0.08))
+        _write_voice(candidates / "claire-b.wav", f0=170, seconds=1.45, harmonics=(1.0, 0.35, 0.18))
+        _write_voice(candidates / "lucie-a.wav", f0=270, seconds=1.05, harmonics=(1.0, 0.05, 0.7, 0.25))
+        _write_voice(candidates / "lucie-b.wav", f0=230, seconds=1.2, harmonics=(1.0, 0.15, 0.5, 0.2))
+        return baseline, candidates, old_hashes
+
+    def test_selects_most_contrasted_cross_role_pair(self):
+        baseline, candidates, old_hashes = self._prepare()
+        try:
+            selected = self.root / "selected"
+            result = select_pair(candidates, baseline, selected)
+            self.assertEqual(result["status"], "selected")
+            self.assertTrue(result["selected"]["eligible"])
+            self.assertEqual(result["selected"]["claire_id"], "claire-a")
+            self.assertIn(result["selected"]["lucie_id"], {"lucie-a", "lucie-b"})
+            self.assertTrue((selected / "reference-claire.wav").is_file())
+            self.assertTrue((selected / "reference-lucie.wav").is_file())
+        finally:
+            for role, digest in old_hashes.items():
+                BASELINE[role]["sha256"] = digest
+
+    def test_identity_render_builds_one_prompt_for_two_lines(self):
+        baseline, candidates, old_hashes = self._prepare()
+        try:
+            selected = self.root / "selected"
+            result = select_pair(candidates, baseline, selected)
+            self.assertEqual(result["status"], "selected")
+            provider = FakeProvider()
+            out = self.root / "claire-result"
+            rendered = render_identity_check("claire", selected, out, provider=provider)
+            self.assertEqual(rendered["rendered_count"], len(IDENTITY_LINES))
+            self.assertEqual(provider.prompts, 1)
+        finally:
+            for role, digest in old_hashes.items():
+                BASELINE[role]["sha256"] = digest
+
+    def test_bundle_has_two_blind_identity_trials(self):
+        baseline, candidates, old_hashes = self._prepare()
+        try:
+            selected = self.root / "selected"
+            self.assertEqual(select_pair(candidates, baseline, selected)["status"], "selected")
+            for role in ("claire", "lucie"):
+                render_identity_check(role, selected, self.root / f"result-{role}", provider=FakeProvider())
+            bundle = self.root / "bundle"
+            manifest = assemble_bundle(self.root, bundle)
+            self.assertEqual(manifest["trial_count"], 2)
+            self.assertTrue((bundle / "index.html").is_file())
+            self.assertIn("correct_reference_for_A", manifest["trials"][0])
+        finally:
+            for role, digest in old_hashes.items():
+                BASELINE[role]["sha256"] = digest
+
+    def test_candidate_catalog_has_two_variants_per_role(self):
+        counts = {"claire": 0, "lucie": 0}
+        for item in CANDIDATES.values():
+            counts[item["role"]] += 1
+        self.assertEqual(counts, {"claire": 2, "lucie": 2})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Efficient contrasted-casting experiment completed.

Technical funnel:
1. Generated exactly 4 neutral VoiceDesign anchors (2 variants per role) on 2 parallel runners.
2. Cheap acoustic prefilter compared all cross-role pairs against the known-confusable Claire/Lucie baseline.
3. Selected `claire-a` + `lucie-b`: score `84.226` vs baseline `24.692` and required `33.334` (~3.41x baseline).
4. Only after that gate passed, rendered 2 neutral Qwen Base x-vector lines per voice.

Human result from `qwen3-contrast-casting-results.json` (schema `qwen3-contrast-casting-identity-v1`):
- neutral-one: selected Référence 1; correct Référence 1 -> PASS
- neutral-two: selected Référence 2; correct Référence 2 -> PASS
- identity: **2/2**
- French: **both-good on both screens**

Final verdict: **PASS for contrasted neutral identity**.

Interpretation: deliberate natural casting separation materially improves blind recognizability and resolves the immediate confusion seen with the previous deliberately similar Claire/Lucie pair.

Scope remains Lab-only. This does NOT yet qualify emotional stability, long-form endurance, age lineage, or production promotion. Production Edge unchanged.

Next gate: direct expressive rendering on the selected contrasted identities before any further architecture complexity.