### PR TITLE
INFRA: publish contrasted Qwen3 identity gate

### DIFF
--- a/voice-lab-pages/request.json
+++ b/voice-lab-pages/request.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "run_id": 32817107201,
-  "artifact": "voice-casting-openvoice-v2-tone-killer",
-  "requested_at": "2026-08-25T08:34:00+02:00"
+  "run_id": 32818950167,
+  "artifact": "voice-casting-qwen3-contrast-casting",
+  "requested_at": "2026-08-25T09:15:00+02:00"
 }


### PR DESCRIPTION
Updates only the trusted Voice Lab Pages publication pointer.

- source run: `32818950167`
- artifact: `voice-casting-qwen3-contrast-casting`
- technical funnel: PASS
- selected casting acoustic score: 84.226 vs 24.692 baseline
- no new audio generation
- no production renderer changes
- PR #82 remains unmerged pending the 2-screen human identity gate