### PR TITLE
INFRA: radio-only Voice Lab questionnaires

### DIFF
--- a/.github/workflows/voice-lab-radio-only-repack.yml
+++ b/.github/workflows/voice-lab-radio-only-repack.yml
@@ -1,0 +1,68 @@
+name: Voice Lab Radio-only Repack
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/voice-lab-radio-only-repack.yml
+      - voice-lab-pages/README.md
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  SOURCE_RUN_ID: "32823632721"
+  SOURCE_ARTIFACT: voice-casting-qwen3-contrast-emotion-killer-recovery
+
+jobs:
+  repack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download exact current listening bundle
+        run: gh run download "$SOURCE_RUN_ID" --repo "${{ github.repository }}" -n "$SOURCE_ARTIFACT" -D bundle
+      - name: Replace every dropdown with visible radio controls
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('bundle/index.html')
+          html = path.read_text(encoding='utf-8')
+
+          replacements = {
+              '<label>A : <select id="actingA"><option value="">—</option><option value="yes">Oui</option><option value="no">Non</option></select></label>':
+                  '<fieldset><legend>A</legend><label><input type="radio" name="actingA" value="yes"> Oui</label><label><input type="radio" name="actingA" value="no"> Non</label></fieldset>',
+              '<label>B : <select id="actingB"><option value="">—</option><option value="yes">Oui</option><option value="no">Non</option></select></label>':
+                  '<fieldset><legend>B</legend><label><input type="radio" name="actingB" value="yes"> Oui</label><label><input type="radio" name="actingB" value="no"> Non</label></fieldset>',
+              '<label><select id="french"><option value="">—</option><option value="both-good">Les deux sont bons</option><option value="a-defect">Défaut éliminatoire sur A</option><option value="b-defect">Défaut éliminatoire sur B</option><option value="both-defect">Défaut éliminatoire sur les deux</option></select></label>':
+                  '<fieldset><legend>Qualité du français</legend><label><input type="radio" name="french" value="both-good"> Les deux sont bons</label><label><input type="radio" name="french" value="a-defect"> Défaut éliminatoire sur A</label><label><input type="radio" name="french" value="b-defect"> Défaut éliminatoire sur B</label><label><input type="radio" name="french" value="both-defect"> Défaut éliminatoire sur les deux</label></fieldset>',
+              "const a=document.getElementById('actingA').value,b=document.getElementById('actingB').value,f=document.getElementById('french').value;":
+                  "const actA=document.querySelector('input[name=actingA]:checked'),actB=document.querySelector('input[name=actingB]:checked'),fr=document.querySelector('input[name=french]:checked');const a=actA?actA.value:'',b=actB?actB.value:'',f=fr?fr.value:'';",
+          }
+
+          for old, new in replacements.items():
+              if old not in html:
+                  raise SystemExit(f'expected UI fragment not found: {old[:80]}')
+              html = html.replace(old, new)
+
+          if '<select' in html.lower():
+              raise SystemExit('radio-only policy violated: <select> remains in page')
+          for name in ('identity', 'actingA', 'actingB', 'french'):
+              if f'name="{name}"' not in html:
+                  raise SystemExit(f'missing radio group: {name}')
+
+          path.write_text(html, encoding='utf-8')
+          print('Radio-only UI verified: identity, actingA, actingB, french; zero <select>.')
+          PY
+      - name: Upload radio-only bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: voice-casting-qwen3-contrast-emotion-radio-only
+          path: bundle/
+          if-no-files-found: error
+          retention-days: 14

--- a/voice-lab-pages/README.md
+++ b/voice-lab-pages/README.md
@@ -15,6 +15,7 @@ Rules:
 - Pages is public, so do not publish confidential/proprietary anchors or media;
 - published pages get `noindex,nofollow` as a courtesy, not an access-control mechanism;
 - human results continue to export locally as JSON;
+- listening questionnaires use visible radio buttons for every choice; dropdown/select controls are not used;
 - Pages publication is not production promotion and has no effect on the production renderer.
 
 `request.json` stays disabled between tests. After a technical PASS, update it to the exact run id and artifact name. The trusted `main` workflow validates and deploys that artifact.


### PR DESCRIPTION
Implements the requested Voice Lab UI rule: all questionnaire choices are visible radio buttons; dropdown/select controls are forbidden.

For the current contrasted-emotion test, this PR repacks the exact existing artifact from run `32823632721` without regenerating audio, replaces acting/French dropdowns with radio groups, asserts zero `<select>` remains, and uploads a radio-only bundle.

Also records the radio-only rule in `voice-lab-pages/README.md`.