### PR TITLE
INFRA: publish radio-only contrasted emotion gate

### DIFF
--- a/voice-lab-pages/request.json
+++ b/voice-lab-pages/request.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "run_id": 32823632721,
-  "artifact": "voice-casting-qwen3-contrast-emotion-killer-recovery",
-  "requested_at": "2026-08-25T09:51:00+02:00"
+  "run_id": 32824408543,
+  "artifact": "voice-casting-qwen3-contrast-emotion-radio-only",
+  "requested_at": "2026-08-25T09:58:00+02:00"
 }


### PR DESCRIPTION
Publishes the already-generated contrasted-emotion listening bundle after UI-only repack.

- source repack run: `32824408543`
- artifact: `voice-casting-qwen3-contrast-emotion-radio-only`
- artifact id: `9554320737`
- artifact digest: `sha256:5fa19fb292f29a8680238a806605b8cfa57dd118e22177e7e83421e729cd5373`
- no audio regeneration
- all questionnaire choices are radio buttons; zero `<select>` remains