### PR TITLE
LAB: fixed speaker-id + independent emotion killer

### DIFF
--- a/.github/workflows/voice-casting-qwen3-customvoice-identity-emotion.yml
+++ b/.github/workflows/voice-casting-qwen3-customvoice-identity-emotion.yml
@@ -1,0 +1,230 @@
+name: Voice Casting Qwen3 CustomVoice Identity Emotion Killer
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - src/audio_engine/voice_lab_qwen3_customvoice_identity_emotion.py
+      - tests/test_voice_lab_qwen3_customvoice_identity_emotion.py
+      - .github/workflows/voice-casting-qwen3-customvoice-identity-emotion.yml
+
+permissions:
+  contents: read
+
+env:
+  QWEN_REV: 022e286b98fbec7e1e916cb940cdf532cd9f488e
+  MODEL_ID: Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice
+  MODEL_REV: b611c9f8f2ad5c741ed9c7a0a6a3750e43e0dfd7
+  TOKENIZERS_PARALLELISM: "false"
+  OMP_NUM_THREADS: "2"
+  MKL_NUM_THREADS: "2"
+  HF_HUB_DISABLE_TELEMETRY: "1"
+  PIP_NO_CACHE_DIR: "1"
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Run offline architecture gates
+        run: |
+          python -m pip install --disable-pip-version-check -e .
+          python -m unittest tests.test_voice_lab_qwen3_customvoice_identity_emotion -v
+
+  render:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        role: [serena, vivian]
+    env:
+      ROLE: ${{ matrix.role }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Free runner disk
+        run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+      - name: Install core engine
+        run: python -m pip install --disable-pip-version-check -e .
+      - name: Checkout pinned Qwen3 source
+        run: |
+          git clone --filter=blob:none https://github.com/QwenLM/Qwen3-TTS.git qwen3-upstream
+          cd qwen3-upstream
+          git checkout "$QWEN_REV"
+          test "$(git rev-parse HEAD)" = "$QWEN_REV"
+      - name: Install isolated CPU inference stack
+        run: |
+          python -m pip install --disable-pip-version-check --index-url https://download.pytorch.org/whl/cpu torch torchaudio
+          python -m pip install --disable-pip-version-check -e ./qwen3-upstream
+          python -m pip check
+      - name: Download pinned CustomVoice model
+        run: |
+          python - <<'PY'
+          import os
+          from huggingface_hub import snapshot_download
+          path = snapshot_download(
+              repo_id=os.environ["MODEL_ID"],
+              revision=os.environ["MODEL_REV"],
+              local_dir="qwen3-customvoice-model",
+          )
+          print(path)
+          PY
+          test -f qwen3-customvoice-model/model.safetensors
+          test -f qwen3-customvoice-model/speech_tokenizer/model.safetensors
+      - name: Render exactly two emotions for one fixed speaker id
+        run: |
+          python - <<'PY'
+          import json, os, random, time
+          from pathlib import Path
+
+          import numpy as np
+          import soundfile as sf
+          import torch
+          from qwen_tts import Qwen3TTSModel
+          from transformers.utils import logging as transformers_logging
+
+          from audio_engine.voice_lab_qwen3_customvoice_identity_emotion import (
+              CASES,
+              COMMON_TEXT,
+              character_spec,
+          )
+
+          role = os.environ["ROLE"]
+          spec = character_spec(role)
+          seed = int(spec["seed"])
+          model = Qwen3TTSModel.from_pretrained(
+              "qwen3-customvoice-model",
+              device_map="cpu",
+              dtype=torch.bfloat16,
+              attn_implementation="eager",
+          )
+          transformers_logging.disable_progress_bar()
+          supported_speakers = {str(item).lower() for item in model.get_supported_speakers()}
+          supported_languages = {str(item).lower() for item in model.get_supported_languages()}
+          if spec["speaker"].lower() not in supported_speakers:
+              raise SystemExit(f"speaker id not supported: {spec['speaker']}")
+          if "french" not in supported_languages:
+              raise SystemExit("French not supported by pinned CustomVoice model")
+
+          root = Path("render-output")
+          clips = root / "clips"
+          clips.mkdir(parents=True)
+          rendered = []
+          for case in CASES:
+              random.seed(seed)
+              np.random.seed(seed)
+              torch.manual_seed(seed)
+              started = time.monotonic()
+              print(f"START {role} {spec['speaker']} {case['id']}", flush=True)
+              wavs, sr = model.generate_custom_voice(
+                  text=COMMON_TEXT,
+                  language="French",
+                  speaker=spec["speaker"],
+                  instruct=case["instruction"],
+                  non_streaming_mode=True,
+                  do_sample=True,
+                  max_new_tokens=512,
+              )
+              out = clips / f"{case['id']}.wav"
+              sf.write(out, wavs[0], sr)
+              elapsed = round(time.monotonic() - started, 2)
+              print(f"SUCCESS {role} {case['id']} {elapsed}s", flush=True)
+              rendered.append(
+                  {
+                      "id": case["id"],
+                      "file": f"clips/{case['id']}.wav",
+                      "render_seconds": elapsed,
+                  }
+              )
+
+          result = {
+              "schema": "qwen3-customvoice-character-v1",
+              "status": "success",
+              "role": role,
+              "speaker": spec["speaker"],
+              "seed": seed,
+              "rendered_count": len(rendered),
+              "rendered": rendered,
+          }
+          if result["rendered_count"] != 2:
+              raise SystemExit("clip budget violated")
+          (root / "character-result.json").write_text(
+              json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+          )
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: qwen3-customvoice-killer-${{ matrix.role }}
+          path: render-output/
+          if-no-files-found: error
+          retention-days: 14
+
+  bundle:
+    needs: render
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      eligible: ${{ steps.gate.outputs.eligible }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install core engine
+        run: python -m pip install --disable-pip-version-check -e .
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: qwen3-customvoice-killer-*
+          path: inputs
+      - name: Apply topology gate and build human bundle only on merit
+        id: gate
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+
+          from audio_engine.voice_lab_qwen3_customvoice_identity_emotion import assemble_bundle
+
+          result = assemble_bundle("inputs", "bundle")
+          print(json.dumps(
+              {
+                  "status": result["status"],
+                  "prefilter": result["prefilter"],
+                  "scores": {
+                      key: value["score"]
+                      for key, value in result["distance_diagnostics_not_identity_proof"].items()
+                  },
+                  "trial_count": result["trial_count"],
+              },
+              ensure_ascii=False,
+              indent=2,
+          ))
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as out:
+              out.write(f"eligible={'true' if result['status'] == 'human-gate-ready' else 'false'}\n")
+          PY
+      - name: Upload two-screen radio-only human gate
+        if: steps.gate.outputs.eligible == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: voice-casting-qwen3-customvoice-identity-emotion
+          path: bundle/
+          if-no-files-found: error
+          retention-days: 14
+      - name: Upload diagnostic only on automatic reject
+        if: steps.gate.outputs.eligible != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwen3-customvoice-identity-emotion-auto-reject
+          path: bundle/manifest.json
+          if-no-files-found: error
+          retention-days: 14

--- a/src/audio_engine/voice_lab_qwen3_customvoice_identity_emotion.py
+++ b/src/audio_engine/voice_lab_qwen3_customvoice_identity_emotion.py
@@ -1,0 +1,251 @@
+"""Qwen3 CustomVoice killer for explicit speaker-id / emotion separation.
+
+Lab only. This experiment does not attempt to reproduce the failed Claire/Lucie
+VoiceDesign cast. It tests a narrower architectural hypothesis: a fixed speaker
+identifier must remain more stable across emotion than two different speaker
+identities are similar within the same emotion.
+"""
+from __future__ import annotations
+
+import json
+import random
+import shutil
+from pathlib import Path
+
+from .voice_casting_distance import compare_anchors
+
+SCHEMA = "qwen3-customvoice-identity-emotion-killer-v1"
+QWEN_REVISION = "022e286b98fbec7e1e916cb940cdf532cd9f488e"
+MODEL_ID = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+MODEL_REVISION = "b611c9f8f2ad5c741ed9c7a0a6a3750e43e0dfd7"
+BLIND_SEED = 2026082567
+
+# Built-in Qwen speaker IDs: identity is categorical and separate from `instruct`.
+CHARACTERS = {
+    "serena": {"speaker": "Serena", "seed": 2026082561},
+    "vivian": {"speaker": "Vivian", "seed": 2026082571},
+}
+
+# Same text in both emotions removes text/duration as a confound for the cheap gate.
+COMMON_TEXT = (
+    "Ils sont là, juste derrière la porte. "
+    "Je savais qu'ils finiraient par revenir."
+)
+
+CASES = (
+    {
+        "id": "panic",
+        "label": "Panique urgente",
+        "instruction": (
+            "Panique urgente et crédible. Parle avec un souffle court, un débit accéléré "
+            "et une tension élevée. Reste intelligible et naturelle, sans caricature."
+        ),
+    },
+    {
+        "id": "sadness-contained",
+        "label": "Tristesse contenue",
+        "instruction": (
+            "Tristesse contenue et résignée. Parle avec une énergie basse, un souffle "
+            "légèrement fragile et beaucoup de retenue. Aucun sanglot, aucun mélodrame."
+        ),
+    },
+)
+
+
+def character_spec(role: str) -> dict:
+    if role not in CHARACTERS:
+        raise ValueError(f"unknown role: {role}")
+    return {"role": role, **CHARACTERS[role]}
+
+
+def case_spec(case_id: str) -> dict:
+    case = next((item for item in CASES if item["id"] == case_id), None)
+    if case is None:
+        raise ValueError(f"unknown case: {case_id}")
+    return dict(case)
+
+
+def experiment_spec() -> dict:
+    return {
+        "schema": SCHEMA,
+        "architecture": "qwen3-customvoice-fixed-speaker-id-plus-independent-instruct",
+        "qwen_revision": QWEN_REVISION,
+        "model": {"id": MODEL_ID, "revision": MODEL_REVISION},
+        "language": "French",
+        "text": COMMON_TEXT,
+        "characters": {role: character_spec(role) for role in CHARACTERS},
+        "cases": [dict(case) for case in CASES],
+        "generation_contract": {
+            "speaker_channel": "fixed built-in speaker id",
+            "emotion_channel": "instruct only",
+            "same_text_across_emotions": True,
+            "clip_count": 4,
+        },
+        "automatic_gate": {
+            "rule": "min(cross-speaker same-emotion) > max(same-speaker cross-emotion)",
+            "threshold_tuning": False,
+            "claim": "cheap topology prefilter only; not speaker-identity proof",
+        },
+        "human_gate": {
+            "screens": 2,
+            "identity": "2/2 blind cross-emotion mappings correct",
+            "acting": "4/4 yes",
+            "french": "both-good on both screens",
+            "ui": "radio-only",
+        },
+        "claims": {
+            "architecture_qualified": False,
+            "custom_character_catalog_qualified": False,
+            "long_form_qualified": False,
+            "age_lineage": False,
+            "production_promoted": False,
+        },
+    }
+
+
+def topology_gate(distances: dict) -> dict:
+    required = {"same_serena", "same_vivian", "cross_panic", "cross_sadness-contained"}
+    if set(distances) != required:
+        missing = sorted(required - set(distances))
+        extra = sorted(set(distances) - required)
+        raise ValueError(f"invalid topology distances; missing={missing}, extra={extra}")
+    scores = {key: float(value["score"]) for key, value in distances.items()}
+    max_within = max(scores["same_serena"], scores["same_vivian"])
+    min_cross = min(scores["cross_panic"], scores["cross_sadness-contained"])
+    margin = min_cross - max_within
+    return {
+        "eligible": margin > 0.0,
+        "max_same_speaker_cross_emotion": round(max_within, 3),
+        "min_cross_speaker_same_emotion": round(min_cross, 3),
+        "topology_margin": round(margin, 3),
+        "rule": "min_cross > max_within",
+        "claim": "prefilter-only-not-speaker-identity-qualification",
+    }
+
+
+def _role_root(root: Path, role: str) -> Path:
+    matches = []
+    for path in Path(root).rglob("character-result.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("role") == role:
+            matches.append(path.parent)
+    if len(matches) != 1:
+        raise ValueError(f"expected one render result for {role}, got {len(matches)}")
+    return matches[0]
+
+
+def assemble_bundle(input_root, output_dir, *, seed: int = BLIND_SEED) -> dict:
+    input_root, output_dir = Path(input_root), Path(output_dir)
+    clips_dir = output_dir / "clips"
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    rendered = {}
+    for role in CHARACTERS:
+        root = _role_root(input_root, role)
+        result = json.loads((root / "character-result.json").read_text(encoding="utf-8"))
+        spec = character_spec(role)
+        if result.get("status") != "success":
+            raise ValueError(f"render failed for {role}")
+        if result.get("speaker") != spec["speaker"] or int(result.get("seed")) != int(spec["seed"]):
+            raise ValueError(f"speaker contract mismatch for {role}")
+        by_id = {item["id"]: item for item in result.get("rendered", [])}
+        expected = {case["id"] for case in CASES}
+        if set(by_id) != expected:
+            raise ValueError(f"incomplete cases for {role}")
+        for case in CASES:
+            source = root / by_id[case["id"]]["file"]
+            name = f"{role}--{case['id']}.wav"
+            shutil.copy2(source, clips_dir / name)
+            rendered[(role, case["id"])] = f"clips/{name}"
+
+    distances = {
+        "same_serena": compare_anchors(
+            output_dir / rendered[("serena", "panic")],
+            output_dir / rendered[("serena", "sadness-contained")],
+        ),
+        "same_vivian": compare_anchors(
+            output_dir / rendered[("vivian", "panic")],
+            output_dir / rendered[("vivian", "sadness-contained")],
+        ),
+        "cross_panic": compare_anchors(
+            output_dir / rendered[("serena", "panic")],
+            output_dir / rendered[("vivian", "panic")],
+        ),
+        "cross_sadness-contained": compare_anchors(
+            output_dir / rendered[("serena", "sadness-contained")],
+            output_dir / rendered[("vivian", "sadness-contained")],
+        ),
+    }
+    prefilter = topology_gate(distances)
+
+    manifest = {
+        **experiment_spec(),
+        "status": "human-gate-ready" if prefilter["eligible"] else "auto-rejected",
+        "distance_diagnostics_not_identity_proof": distances,
+        "prefilter": prefilter,
+        "trial_count": 2 if prefilter["eligible"] else 0,
+        "rendered": {
+            f"{role}:{case['id']}": rendered[(role, case["id"])]
+            for role in CHARACTERS
+            for case in CASES
+        },
+    }
+
+    if prefilter["eligible"]:
+        trials = _build_trials(rendered, seed=seed)
+        manifest["trials"] = trials
+        _write_player(output_dir, trials)
+
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+def _build_trials(rendered: dict, *, seed: int) -> list[dict]:
+    rnd = random.Random(seed)
+    by_id = {case["id"]: case for case in CASES}
+    pairs = (("panic", "sadness-contained"), ("sadness-contained", "panic"))
+    trials = []
+    for target_id, reference_id in pairs:
+        options = [{"role": role, "file": rendered[(role, target_id)]} for role in CHARACTERS]
+        rnd.shuffle(options)
+        trials.append(
+            {
+                "id": f"{target_id}-from-{reference_id}",
+                "label": by_id[target_id]["label"],
+                "text": COMMON_TEXT,
+                "reference_emotion": reference_id,
+                "target_emotion": target_id,
+                "references": [
+                    {"role": "serena", "label": "Référence 1", "file": rendered[("serena", reference_id)]},
+                    {"role": "vivian", "label": "Référence 2", "file": rendered[("vivian", reference_id)]},
+                ],
+                "options": [
+                    {"letter": letter, **option} for letter, option in zip("AB", options)
+                ],
+                "correct_reference_for_A": (
+                    "Référence 1" if options[0]["role"] == "serena" else "Référence 2"
+                ),
+            }
+        )
+    return trials
+
+
+def _write_player(output_dir: Path, trials: list[dict]) -> None:
+    public = [
+        {
+            "id": trial["id"],
+            "label": trial["label"],
+            "text": trial["text"],
+            "references": trial["references"],
+            "options": [{"letter": item["letter"], "file": item["file"]} for item in trial["options"]],
+        }
+        for trial in trials
+    ]
+    public_json = json.dumps(public, ensure_ascii=False).replace("</", "<\\/")
+    mapping_json = json.dumps({"trials": trials}, ensure_ascii=False).replace("</", "<\\/")
+    html = f'''<!doctype html><html lang="fr"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Identité fixe + émotion séparée</title><style>body{{font-family:system-ui,sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem}}.grid{{display:grid;grid-template-columns:1fr 1fr;gap:1rem}}.card{{border:1px solid #999;border-radius:12px;padding:1rem}}audio{{width:100%}}label{{display:block;margin:.55rem 0}}fieldset{{border:0;padding:0;margin:1rem 0}}legend{{font-weight:700;margin-bottom:.35rem}}button{{padding:.7rem 1rem;margin:.4rem}}@media(max-width:650px){{.grid{{grid-template-columns:1fr}}}}</style></head><body><h1>Identité fixe + émotion séparée</h1><p>2 écrans. Les références jouent la même phrase dans l’émotion opposée. Associez A à sa voix de référence, puis jugez le jeu et le français.</p><main id="app"></main><script>const trials={public_json};const mapping={mapping_json};let i=0;const responses={{}};function audio(src){{return `<audio controls preload="none" src="${{src}}"></audio>`}}function radio(name,value,label){{return `<label><input type="radio" name="${{name}}" value="${{value}}"> ${{label}}</label>`}}function checked(name){{const el=document.querySelector(`input[name="${{name}}"]:checked`);return el?el.value:''}}function render(){{const t=trials[i];document.getElementById('app').innerHTML=`<h2>${{i+1}}/2 — ${{t.label}}</h2><p>${{t.text}}</p><div class="grid"><div class="card"><h3>Référence 1</h3>${{audio(t.references[0].file)}}<h3>Référence 2</h3>${{audio(t.references[1].file)}}</div><div class="card"><h3>A</h3>${{audio(t.options[0].file)}}<h3>B</h3>${{audio(t.options[1].file)}}</div></div><fieldset><legend>À quelle référence correspond A ?</legend>${{radio('identity','Référence 1','Référence 1')}}${{radio('identity','Référence 2','Référence 2')}}${{radio('identity','uncertain','Impossible à distinguer')}}</fieldset><fieldset><legend>Le jeu de A correspond-il à l’émotion annoncée ?</legend>${{radio('actingA','yes','Oui')}}${{radio('actingA','no','Non')}}</fieldset><fieldset><legend>Le jeu de B correspond-il à l’émotion annoncée ?</legend>${{radio('actingB','yes','Oui')}}${{radio('actingB','no','Non')}}</fieldset><fieldset><legend>Français</legend>${{radio('french','both-good','Les deux sont bons')}}${{radio('french','a-defect','Défaut éliminatoire sur A')}}${{radio('french','b-defect','Défaut éliminatoire sur B')}}${{radio('french','both-defect','Défaut éliminatoire sur les deux')}}</fieldset><p><button onclick="save()">${{i===trials.length-1?'Terminer':'Suivant'}}</button></p>`}}function save(){{const identity=checked('identity'),actingA=checked('actingA'),actingB=checked('actingB'),french=checked('french');if(!identity||!actingA||!actingB||!french){{alert('Répondez aux quatre questions.');return}}responses[trials[i].id]={{identity,actingA,actingB,french}};i++;if(i<trials.length)render();else finish()}}function finish(){{document.getElementById('app').innerHTML=`<h2>Terminé</h2><p>Exportez le JSON et envoyez-le dans la conversation.</p><button onclick="download()">Exporter le JSON</button>`}}function download(){{const blob=new Blob([JSON.stringify({{schema:'qwen3-customvoice-identity-emotion-results-v1',exported_at:new Date().toISOString(),responses,mapping}},null,2)],{{type:'application/json'}});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='qwen3-customvoice-identity-emotion-results.json';a.click();URL.revokeObjectURL(a.href)}}render();</script></body></html>'''
+    if "<select" in html.lower():
+        raise AssertionError("Voice Lab questionnaires must be radio-only")
+    (Path(output_dir) / "index.html").write_text(html, encoding="utf-8")

--- a/tests/test_voice_lab_qwen3_customvoice_identity_emotion.py
+++ b/tests/test_voice_lab_qwen3_customvoice_identity_emotion.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from audio_engine.voice_lab_qwen3_customvoice_identity_emotion import (
+    CASES,
+    CHARACTERS,
+    COMMON_TEXT,
+    MODEL_ID,
+    _build_trials,
+    _write_player,
+    experiment_spec,
+    topology_gate,
+)
+
+
+class CustomVoiceIdentityEmotionTests(unittest.TestCase):
+    def test_architecture_separates_speaker_and_emotion_channels(self):
+        spec = experiment_spec()
+        self.assertEqual(MODEL_ID, "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice")
+        self.assertEqual(set(CHARACTERS), {"serena", "vivian"})
+        self.assertEqual([case["id"] for case in CASES], ["panic", "sadness-contained"])
+        self.assertTrue(spec["generation_contract"]["same_text_across_emotions"])
+        self.assertEqual(spec["generation_contract"]["clip_count"], 4)
+        self.assertEqual(spec["generation_contract"]["speaker_channel"], "fixed built-in speaker id")
+        self.assertEqual(spec["generation_contract"]["emotion_channel"], "instruct only")
+        self.assertTrue(COMMON_TEXT.startswith("Ils sont là"))
+
+    def test_emotion_instructions_do_not_carry_speaker_identity(self):
+        speakers = {item["speaker"].lower() for item in CHARACTERS.values()}
+        for case in CASES:
+            instruction = case["instruction"].lower()
+            self.assertTrue(all(speaker not in instruction for speaker in speakers))
+
+    def test_topology_gate_has_no_tuned_absolute_threshold(self):
+        good = {
+            "same_serena": {"score": 22.0},
+            "same_vivian": {"score": 18.0},
+            "cross_panic": {"score": 41.0},
+            "cross_sadness-contained": {"score": 35.0},
+        }
+        result = topology_gate(good)
+        self.assertTrue(result["eligible"])
+        self.assertEqual(result["topology_margin"], 13.0)
+
+        bad = dict(good)
+        bad["same_serena"] = {"score": 36.0}
+        self.assertFalse(topology_gate(bad)["eligible"])
+
+    def test_two_screen_gate_reuses_only_four_clips_and_is_radio_only(self):
+        rendered = {
+            (role, case["id"]): f"clips/{role}--{case['id']}.wav"
+            for role in CHARACTERS
+            for case in CASES
+        }
+        trials = _build_trials(rendered, seed=17)
+        self.assertEqual(len(trials), 2)
+        files = {
+            item["file"]
+            for trial in trials
+            for item in trial["references"] + trial["options"]
+        }
+        self.assertEqual(len(files), 4)
+        self.assertEqual(
+            {trial["target_emotion"] for trial in trials},
+            {"panic", "sadness-contained"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_player(Path(tmp), trials)
+            html = (Path(tmp) / "index.html").read_text(encoding="utf-8").lower()
+        self.assertNotIn("<select", html)
+        self.assertIn('type="radio"', html)
+        for group in ("identity", "actinga", "actingb", "french"):
+            self.assertIn(f"radio('{group}'", html)
+
+    def test_no_promotion_claims(self):
+        claims = experiment_spec()["claims"]
+        self.assertFalse(claims["architecture_qualified"])
+        self.assertFalse(claims["custom_character_catalog_qualified"])
+        self.assertFalse(claims["long_form_qualified"])
+        self.assertFalse(claims["age_lineage"])
+        self.assertFalse(claims["production_promoted"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Architecture-control killer after direct VoiceDesign, recasting, and DSP-signature failure.

Hypothesis: speaker identity must be carried by an explicit fixed speaker channel, while emotion is carried independently.

This PR uses Qwen3-TTS 1.7B CustomVoice as the smallest clean control available in the existing Qwen stack:
- fixed built-in speaker IDs: Serena + Vivian;
- `speaker=` carries identity; `instruct=` carries emotion only;
- French explicitly selected;
- exactly 4 generated clips total: 2 speakers x panic + contained sadness;
- exactly the same French text across both emotions to remove text/duration as a topology-gate confound;
- cheap automatic gate before human listening: every cross-speaker/same-emotion distance must exceed every same-speaker/cross-emotion drift; no tuned absolute threshold;
- only if that gate passes: 2 cross-emotion human screens, radio-only, strict identity 2/2 + acting 4/4 + French both-good 2/2.

This is an architectural control, not a proposed final character catalog: Serena/Vivian are preset Qwen voices.

## Result — REJECT
Run `32837618339` completed successfully but the automatic topology prefilter rejected the architecture before human listening:
- same Serena / cross emotion: 48.689
- same Vivian / cross emotion: 43.680
- cross speaker / panic: 53.392
- cross speaker / contained sadness: 45.467
- max within-speaker drift: 48.689
- min cross-speaker separation: 45.467
- topology margin: **-3.222**

The fixed `speaker=` channel therefore did not keep acoustic identity topology invariant enough across emotion for this killer. No Pages update and no human gate. No tuning of seeds, prompts, or thresholds will follow.

Next architectural direction: expressive source speech -> zero-shot voice conversion into a fixed target reference, with X-VC or a legally/operationally healthier equivalent evaluated behind a cheap dependency/license gate.

Production Edge unchanged. No long-form, age-lineage, or production claim.