### PR TITLE
LAB: freeze GPU-ready RVC v2/32k Lucie training package

### DIFF
--- a/.github/workflows/voice-casting-rvc-gpu-package-dryrun.yml
+++ b/.github/workflows/voice-casting-rvc-gpu-package-dryrun.yml
@@ -78,14 +78,15 @@ jobs:
           mkdir -p pilot
           gh run download "$PILOT_RUN_ID" --repo "${{ github.repository }}" -n "$PILOT_ARTIFACT" -D pilot
           python - <<'PY'
-          import json, shutil, tempfile
+          import json
           from pathlib import Path
           from audio_engine.voice_lab_rvc_gpu_package import validate_dataset_manifest
-          pilot=json.loads(Path('pilot/manifest.json').read_text())
+          manifest=Path('pilot/qualified/manifest.json')
+          pilot=json.loads(manifest.read_text())
           assert pilot['status']=='pilot-pass'
           assert abs(float(pilot['accepted_duration_seconds'])-51.12)<1e-6
           try:
-              validate_dataset_manifest(Path('pilot/manifest.json'))
+              validate_dataset_manifest(manifest)
           except ValueError as e:
               print('EXPECTED_PILOT_REJECT_FOR_TRAINING',e)
           else:

--- a/.github/workflows/voice-casting-rvc-gpu-package-dryrun.yml
+++ b/.github/workflows/voice-casting-rvc-gpu-package-dryrun.yml
@@ -1,0 +1,115 @@
+name: Voice Casting RVC GPU Package Dry Run
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - src/audio_engine/voice_lab_rvc_gpu_package.py
+      - tests/test_voice_lab_rvc_gpu_package.py
+      - scripts/voice_lab_rvc_gpu_train.sh
+      - .github/workflows/voice-casting-rvc-gpu-package-dryrun.yml
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  RVC_REV: 81eed5e8f68b6bed1789f682fe78cdd324495afc
+  PILOT_RUN_ID: "32939596171"
+  PILOT_ARTIFACT: rvc-lucie-neutral-dataset-pilot-qualified-parallel
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Validate package code and frozen contract
+        run: |
+          python -m pip install --disable-pip-version-check -e .
+          python -m unittest tests.test_voice_lab_rvc_gpu_package -v
+          python -m py_compile src/audio_engine/voice_lab_rvc_gpu_package.py
+          bash -n scripts/voice_lab_rvc_gpu_train.sh
+          if command -v shellcheck >/dev/null; then shellcheck -x scripts/voice_lab_rvc_gpu_train.sh; fi
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from audio_engine.voice_lab_rvc_gpu_package import package_spec, expected_training_argv
+          Path('evidence').mkdir()
+          spec=package_spec()
+          assert spec['training']['batch_size']==4
+          assert spec['training']['total_epochs']==200
+          assert spec['training']['seed']==1234
+          assert spec['training']['parameter_tuning'] is False
+          assert spec['dataset_contract']['accepted_duration_seconds_min']==300.0
+          assert spec['dataset_contract']['aggregate_wer_max']==0.05
+          argv=expected_training_argv()
+          assert argv == ['train/train.py','-e','lucie_rvc_v2_32k','-sr','32k','-f0','1','-bs','4','-g','0','-te','200','-se','25','-pg','assets/pretrained_v2/f0G32k.pth','-pd','assets/pretrained_v2/f0D32k.pth','-l','1','-c','0','-sw','1','-v','v2']
+          Path('evidence/package-spec.json').write_text(json.dumps(spec,indent=2),encoding='utf-8')
+          print(json.dumps(spec,indent=2))
+          PY
+      - name: Verify exact pinned RVC source and CLI surface
+        run: |
+          git clone --filter=blob:none https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI.git RVC
+          git -C RVC checkout "$RVC_REV"
+          test "$(git -C RVC rev-parse HEAD)" = "$RVC_REV"
+          grep -qi "MIT License" RVC/LICENSE
+          python - <<'PY'
+          import subprocess
+          from audio_engine.voice_lab_rvc_gpu_package import RVC_CONFIG_BLOB,RVC_SOURCE_BLOBS
+          def blob(path): return subprocess.check_output(['git','-C','RVC','hash-object',path],text=True).strip()
+          assert blob('configs/v2/32k.json')==RVC_CONFIG_BLOB
+          for path,expected in RVC_SOURCE_BLOBS.items():
+              got=blob(path)
+              assert got==expected,(path,got,expected)
+          print('all pinned RVC source blobs PASS')
+          PY
+          grep -q 'train\\train.py -e "EXPERIMENT"' RVC/docs/en/cli.md
+          grep -q 'extract_f0.py cuda 1 0 0' RVC/docs/en/cli.md
+          grep -q 'extract_hubert_feature.py cuda:0 1 0 0' RVC/docs/en/cli.md
+          grep -q 'train\\train_index.py "EXPERIMENT" v2' RVC/docs/en/cli.md
+      - name: Prove pilot cannot accidentally authorize GPU training
+        run: |
+          mkdir -p pilot
+          gh run download "$PILOT_RUN_ID" --repo "${{ github.repository }}" -n "$PILOT_ARTIFACT" -D pilot
+          python - <<'PY'
+          import json, shutil, tempfile
+          from pathlib import Path
+          from audio_engine.voice_lab_rvc_gpu_package import validate_dataset_manifest
+          pilot=json.loads(Path('pilot/manifest.json').read_text())
+          assert pilot['status']=='pilot-pass'
+          assert abs(float(pilot['accepted_duration_seconds'])-51.12)<1e-6
+          try:
+              validate_dataset_manifest(Path('pilot/manifest.json'))
+          except ValueError as e:
+              print('EXPECTED_PILOT_REJECT_FOR_TRAINING',e)
+          else:
+              raise SystemExit('51-second pilot incorrectly authorized GPU training')
+          # Positive contract fixture proves the package can accept only the future qualified shape.
+          fixture={
+            'status':'dataset-pass','accepted_duration_seconds':305.0,
+            'aggregate_wer':0.01,'expansion_acceptance_rate':0.90,
+            'retries':0,'substitutions':0,
+          }
+          p=Path('evidence/dataset-contract-fixture.json');p.write_text(json.dumps(fixture,indent=2))
+          assert validate_dataset_manifest(p)['status']=='dataset-pass'
+          PY
+      - name: Verify GPU script has no hidden training knobs
+        run: |
+          grep -q -- '-bs 4 -g 0 -te 200 -se 25' scripts/voice_lab_rvc_gpu_train.sh
+          grep -q -- '-l 1 -c 0 -sw 1 -v v2' scripts/voice_lab_rvc_gpu_train.sh
+          grep -q 'GPU contract requires >=10 GiB VRAM' scripts/voice_lab_rvc_gpu_train.sh
+          grep -q 'extract_f0.py cuda 1 0 0' scripts/voice_lab_rvc_gpu_train.sh
+          grep -q 'extract_hubert_feature.py cuda:0 1 0 0' scripts/voice_lab_rvc_gpu_train.sh
+          grep -q 'machine_killer_evaluated.*False' scripts/voice_lab_rvc_gpu_train.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rvc-gpu-handover-package-dryrun
+          path: evidence/
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/voice_lab_rvc_gpu_train.sh
+++ b/scripts/voice_lab_rvc_gpu_train.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Voice Lab only. Usage:
+#   scripts/voice_lab_rvc_gpu_train.sh QUALIFIED_DATASET_DIR WORK_DIR cu118|cu128
+# The dataset directory must contain manifest.json and clips/*.wav from the
+# machine-qualified Lucie corpus. No parameter auto-tuning is performed.
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 QUALIFIED_DATASET_DIR WORK_DIR cu118|cu128" >&2
+  exit 2
+fi
+
+DATASET_DIR="$(realpath "$1")"
+WORK_DIR="$(mkdir -p "$2" && realpath "$2")"
+CUDA_FLAVOR="$3"
+case "$CUDA_FLAVOR" in
+  cu118|cu128) ;;
+  *) echo "CUDA flavor must be cu118 or cu128" >&2; exit 2 ;;
+esac
+
+AUDIO_ENGINE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RVC_DIR="$WORK_DIR/RVC"
+VENV="$WORK_DIR/.venv"
+EXP="lucie_rvc_v2_32k"
+RAW="$RVC_DIR/datasets/lucie-qualified"
+OUT="$WORK_DIR/output"
+RVC_REV="81eed5e8f68b6bed1789f682fe78cdd324495afc"
+MODEL_REPO="lj1995/VoiceConversionWebUI"
+
+mkdir -p "$OUT"
+
+if [[ ! -f "$DATASET_DIR/manifest.json" ]]; then
+  echo "missing $DATASET_DIR/manifest.json" >&2; exit 1
+fi
+if [[ ! -d "$DATASET_DIR/clips" ]]; then
+  echo "missing $DATASET_DIR/clips" >&2; exit 1
+fi
+
+python3.12 -m venv "$VENV"
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install --disable-pip-version-check -e "$AUDIO_ENGINE_ROOT"
+python - <<PY
+from pathlib import Path
+from audio_engine.voice_lab_rvc_gpu_package import validate_dataset_manifest
+m=validate_dataset_manifest(Path(r'''$DATASET_DIR/manifest.json'''))
+print('DATASET_PASS', m['accepted_duration_seconds'], m['aggregate_wer'], m['expansion_acceptance_rate'])
+PY
+
+if [[ ! -d "$RVC_DIR/.git" ]]; then
+  git clone --filter=blob:none https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI.git "$RVC_DIR"
+fi
+git -C "$RVC_DIR" fetch --depth=1 origin "$RVC_REV"
+git -C "$RVC_DIR" checkout --detach FETCH_HEAD
+test "$(git -C "$RVC_DIR" rev-parse HEAD)" = "$RVC_REV"
+grep -qi "MIT License" "$RVC_DIR/LICENSE"
+
+python - <<PY
+import subprocess
+from audio_engine.voice_lab_rvc_gpu_package import RVC_CONFIG_BLOB, RVC_SOURCE_BLOBS
+root=r'''$RVC_DIR'''
+def blob(path):
+    return subprocess.check_output(['git','-C',root,'hash-object',path], text=True).strip()
+assert blob('configs/v2/32k.json') == RVC_CONFIG_BLOB
+for path, expected in RVC_SOURCE_BLOBS.items():
+    got=blob(path)
+    if got != expected: raise SystemExit(f'RVC source blob mismatch {path}: {got}')
+print('RVC_SOURCE_PROVENANCE_PASS')
+PY
+
+if [[ "$CUDA_FLAVOR" == "cu118" ]]; then
+  python -m pip install torch==2.7.1+cu118 torchaudio==2.7.1+cu118 \
+    --index-url https://download.pytorch.org/whl/cu118 --extra-index-url https://pypi.org/simple
+  REQ="$RVC_DIR/requirments_cu118_py312.txt"
+else
+  python -m pip install torch==2.7.1+cu128 torchaudio==2.7.1+cu128 \
+    --index-url https://download.pytorch.org/whl/cu128 --extra-index-url https://pypi.org/simple
+  REQ="$RVC_DIR/requirments_cu128_py312.txt"
+fi
+python -m pip install -r "$REQ"
+python -m pip install --disable-pip-version-check huggingface_hub==0.36.0
+python -m pip check
+
+python - <<'PY'
+import torch
+if not torch.cuda.is_available(): raise SystemExit('CUDA GPU unavailable')
+if torch.cuda.device_count() != 1: raise SystemExit(f'exactly one CUDA GPU required, got {torch.cuda.device_count()}')
+p=torch.cuda.get_device_properties(0)
+mem=p.total_memory/(1024**3)
+print('GPU', p.name, 'VRAM_GiB', mem, 'torch_cuda', torch.version.cuda)
+if mem < 10.0: raise SystemExit('GPU contract requires >=10 GiB VRAM for fixed batch 4; no auto-batch fallback')
+PY
+
+mkdir -p "$RVC_DIR/assets/hubert_base" "$RVC_DIR/assets/rmvpe" "$RVC_DIR/assets/pretrained_v2" "$RVC_DIR/.model-downloads" "$RVC_DIR/logs" "$RVC_DIR/assets/weights" "$RVC_DIR/assets/indices"
+python - <<PY
+import hashlib, json, shutil
+from pathlib import Path
+from huggingface_hub import hf_hub_download
+from audio_engine.voice_lab_rvc_gpu_package import MODEL_ASSETS
+repo='$MODEL_REPO'
+root=Path(r'''$RVC_DIR''')
+# Content hashes are authoritative. main is permitted only because every large
+# executable/model asset is rejected if its bytes differ from this manifest.
+items={
+ 'hubert_base/pytorch_model.bin': root/'assets/hubert_base/pytorch_model.bin',
+ 'hubert_base/config.json': root/'assets/hubert_base/config.json',
+ 'hubert_base/preprocessor_config.json': root/'assets/hubert_base/preprocessor_config.json',
+ 'rmvpe.pt': root/'assets/rmvpe/rmvpe.pt',
+ 'pretrained_v2/f0G32k.pth': root/'assets/pretrained_v2/f0G32k.pth',
+ 'pretrained_v2/f0D32k.pth': root/'assets/pretrained_v2/f0D32k.pth',
+ 'mute.zip': root/'.model-downloads/mute.zip',
+}
+for remote,dst in items.items():
+    src=Path(hf_hub_download(repo_id=repo, filename=remote, revision='main'))
+    dst.parent.mkdir(parents=True,exist_ok=True); shutil.copy2(src,dst)
+large_map={
+ 'assets/hubert_base/pytorch_model.bin':'assets/hubert_base/pytorch_model.bin',
+ 'assets/rmvpe/rmvpe.pt':'assets/rmvpe/rmvpe.pt',
+ 'assets/pretrained_v2/f0G32k.pth':'assets/pretrained_v2/f0G32k.pth',
+ 'assets/pretrained_v2/f0D32k.pth':'assets/pretrained_v2/f0D32k.pth',
+ 'mute.zip':'.model-downloads/mute.zip',
+}
+for key,rel in large_map.items():
+    p=root/rel; got=hashlib.sha256(p.read_bytes()).hexdigest(); expected=MODEL_ASSETS[key]
+    if got!=expected: raise SystemExit(f'bootstrap SHA mismatch {key}: {got}')
+cfg=json.loads((root/'assets/hubert_base/config.json').read_text())
+pre=json.loads((root/'assets/hubert_base/preprocessor_config.json').read_text())
+assert cfg.get('architectures')==['HubertModelWithFinalProj']
+assert pre.get('sampling_rate')==16000 and pre.get('do_normalize') is False
+print('BOOTSTRAP_MODEL_PROVENANCE_PASS')
+PY
+(cd "$RVC_DIR" && python -m zipfile -e .model-downloads/mute.zip logs)
+
+rm -rf "$RAW"
+mkdir -p "$RAW"
+cp "$DATASET_DIR"/clips/*.wav "$RAW"/
+CLIP_COUNT="$(find "$RAW" -maxdepth 1 -type f -name '*.wav' | wc -l)"
+if [[ "$CLIP_COUNT" -lt 1 ]]; then echo "no dataset WAVs" >&2; exit 1; fi
+printf 'staged_clips=%s\n' "$CLIP_COUNT"
+
+cd "$RVC_DIR"
+rm -rf "logs/$EXP"
+mkdir -p "logs/$EXP"
+cp configs/v2/32k.json "logs/$EXP/config.json"
+
+python train/preprocess.py "$RAW" 32000 4 "logs/$EXP" False 3.7
+python train/dataset/extract_f0.py cuda 1 0 0 "logs/$EXP" true
+python train/dataset/extract_hubert_feature.py cuda:0 1 0 0 "logs/$EXP" v2 true
+
+PYTHONPATH="$AUDIO_ENGINE_ROOT/src:$PYTHONPATH" python - <<PY
+from pathlib import Path
+from audio_engine.voice_lab_rvc_gpu_package import write_filelist
+p=write_filelist(Path(r'''$RVC_DIR/logs/$EXP'''), Path(r'''$RVC_DIR'''))
+rows=[x for x in p.read_text().splitlines() if x.strip()]
+print('FILELIST_PASS rows=',len(rows),'real=',len(rows)-2,'mute=',2)
+PY
+
+test -s "logs/$EXP/filelist.txt"
+python train/train.py \
+  -e "$EXP" -sr 32k -f0 1 -bs 4 -g 0 -te 200 -se 25 \
+  -pg assets/pretrained_v2/f0G32k.pth \
+  -pd assets/pretrained_v2/f0D32k.pth \
+  -l 1 -c 0 -sw 1 -v v2
+
+test -s "assets/weights/$EXP.pth"
+python train/train_index.py "$EXP" v2 assets/indices 4 single
+INDEX="$(find "logs/$EXP" -maxdepth 1 -type f -name 'added_IVF*_Flat_nprobe_*_v2.index' | sort | tail -1)"
+test -n "$INDEX" && test -s "$INDEX"
+
+cp "assets/weights/$EXP.pth" "$OUT/$EXP.pth"
+cp "$INDEX" "$OUT/$(basename "$INDEX")"
+cp "$DATASET_DIR/manifest.json" "$OUT/dataset-manifest.json"
+sha256sum "$OUT"/* > "$OUT/SHA256SUMS"
+
+PYTHONPATH="$AUDIO_ENGINE_ROOT/src:$PYTHONPATH" python - <<PY
+import hashlib, json, platform, subprocess
+from pathlib import Path
+import torch
+from audio_engine.voice_lab_rvc_gpu_package import package_spec
+out=Path(r'''$OUT''')
+model=out/'$EXP.pth'
+index=next(out.glob('added_IVF*.index'))
+report=package_spec()
+report.update({
+ 'status':'gpu-training-complete-unqualified',
+ 'model_file':model.name,
+ 'model_sha256':hashlib.sha256(model.read_bytes()).hexdigest(),
+ 'index_file':index.name,
+ 'index_sha256':hashlib.sha256(index.read_bytes()).hexdigest(),
+ 'gpu':torch.cuda.get_device_name(0),
+ 'gpu_vram_bytes':torch.cuda.get_device_properties(0).total_memory,
+ 'torch':torch.__version__,
+ 'torch_cuda':torch.version.cuda,
+ 'python':platform.python_version(),
+ 'training_complete':True,
+ 'machine_killer_evaluated':False,
+ 'human_gate':False,
+ 'production_qualified':False,
+})
+(out/'training-provenance.json').write_text(json.dumps(report,indent=2),encoding='utf-8')
+print(json.dumps(report,indent=2))
+PY
+
+echo "RVC GPU TRAINING COMPLETE — model remains Lab-only and UNQUALIFIED until killer evaluation."
+echo "Outputs: $OUT"

--- a/src/audio_engine/voice_lab_rvc_gpu_package.py
+++ b/src/audio_engine/voice_lab_rvc_gpu_package.py
@@ -1,0 +1,191 @@
+"""Frozen GPU handover contract for learned Lucie identity in the Voice Lab.
+
+This module does not train anything. It defines the exact RVC source/config/model
+provenance and creates deterministic single-speaker v2/32k/F0 file lists.
+Production Edge is intentionally outside this module.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+RVC_REPO = "RVC-Project/Retrieval-based-Voice-Conversion-WebUI"
+RVC_REVISION = "81eed5e8f68b6bed1789f682fe78cdd324495afc"
+RVC_LICENSE = "MIT"
+RVC_CONFIG = "configs/v2/32k.json"
+RVC_CONFIG_BLOB = "09788b030b575bbc812319d18af15ec2815187be"
+RVC_SOURCE_BLOBS = {
+    "train/preprocess.py": "917fb928a12aa45f8d21f6f7f77522df3ff417e7",
+    "train/dataset/extract_f0.py": "22c7c3f56249acc61f46b77b10e3c2b3e81691b7",
+    "train/dataset/extract_hubert_feature.py": "9fd24375668d92f5bbcc1f2a934095c54d7cab1b",
+    "train/train.py": "3a5c51b01a3006bc7ce714a2a939dce817cf80b9",
+    "train/train_index.py": "b3a73e513ae8fbcd791a9959c4ea5e3c63837c22",
+    "train/data_utils.py": "682538a84056d118962925155fb319d0caf7750d",
+    "infer/module/models.py": "d0e612452671f7188e8a13431ac6a9eab29b4ee0",
+    "train/losses.py": "aa7bd81cf596884a8b33e802ae49254d7810a860",
+}
+
+MODEL_REPO = "lj1995/VoiceConversionWebUI"
+MODEL_REPO_LICENSE = "MIT"
+MODEL_ASSETS = {
+    "assets/hubert_base/pytorch_model.bin": "cc8c20f4b90a520757260197a3ff2505705a7adbd20ad9eeaa4e1a9b38442ef5",
+    "assets/rmvpe/rmvpe.pt": "6d62215f4306e3ca278246188607209f09af3dc77ed4232efdd069798c4ec193",
+    "assets/pretrained_v2/f0G32k.pth": "2332611297b8d88c7436de8f17ef5f07a2119353e962cd93cda5806d59a1133d",
+    "assets/pretrained_v2/f0D32k.pth": "bd7134e7793674c85474d5145d2d982e3c5d8124fc7bb6c20f710ed65808fa8a",
+    "mute.zip": "ee948e85213e4ed2f2ba2f8dfcee810bfd0b63131d91450e920bbe1cbd0321d0",
+}
+
+EXPERIMENT = "lucie_rvc_v2_32k"
+SAMPLE_RATE = 32000
+VERSION = "v2"
+IF_F0 = 1
+F0_METHOD = "rmvpe"
+GPU_ID = 0
+BATCH_SIZE = 4
+TOTAL_EPOCHS = 200
+SAVE_EVERY_EPOCHS = 25
+TRAIN_SEED = 1234  # native configs/v2/32k.json value
+PREPROCESS_SLICE_SECONDS = 3.7
+SPEAKER_ID = 0
+MIN_DATASET_SECONDS = 300.0
+MAX_AGGREGATE_WER = 0.05
+MIN_EXPANSION_ACCEPTANCE_RATE = 0.85
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def package_spec() -> dict:
+    return {
+        "schema": "voice-lab-rvc-gpu-package-v1",
+        "role": "lucie",
+        "rvc": {
+            "repo": RVC_REPO,
+            "revision": RVC_REVISION,
+            "license": RVC_LICENSE,
+            "config": RVC_CONFIG,
+            "config_git_blob": RVC_CONFIG_BLOB,
+            "source_git_blobs": dict(RVC_SOURCE_BLOBS),
+        },
+        "bootstrap_models": {
+            "repo": MODEL_REPO,
+            "license": MODEL_REPO_LICENSE,
+            "sha256": dict(MODEL_ASSETS),
+            "mutable_revision_allowed_only_with_hash_verification": True,
+        },
+        "training": {
+            "sample_rate": SAMPLE_RATE,
+            "version": VERSION,
+            "if_f0": IF_F0,
+            "f0_method": F0_METHOD,
+            "gpu_id": GPU_ID,
+            "batch_size": BATCH_SIZE,
+            "total_epochs": TOTAL_EPOCHS,
+            "save_every_epochs": SAVE_EVERY_EPOCHS,
+            "seed": TRAIN_SEED,
+            "preprocess_slice_seconds": PREPROCESS_SLICE_SECONDS,
+            "cache_dataset_in_gpu": False,
+            "single_speaker_id": SPEAKER_ID,
+            "parameter_tuning": False,
+        },
+        "dataset_contract": {
+            "status": "dataset-pass",
+            "accepted_duration_seconds_min": MIN_DATASET_SECONDS,
+            "aggregate_wer_max": MAX_AGGREGATE_WER,
+            "expansion_acceptance_rate_min": MIN_EXPANSION_ACCEPTANCE_RATE,
+            "retries": 0,
+            "substitutions": 0,
+        },
+        "human_gate": False,
+        "production_qualified": False,
+    }
+
+
+def validate_dataset_manifest(path: Path) -> dict:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if data.get("status") != "dataset-pass":
+        raise ValueError("RVC GPU handover requires a machine-qualified dataset-pass manifest")
+    if float(data.get("accepted_duration_seconds", 0.0)) < MIN_DATASET_SECONDS:
+        raise ValueError("qualified dataset is shorter than 300 seconds")
+    if float(data.get("aggregate_wer", 1.0)) > MAX_AGGREGATE_WER + 1e-12:
+        raise ValueError("qualified dataset aggregate WER exceeds 0.05")
+    if float(data.get("expansion_acceptance_rate", 0.0)) < MIN_EXPANSION_ACCEPTANCE_RATE - 1e-12:
+        raise ValueError("qualified dataset expansion acceptance rate is below 0.85")
+    if int(data.get("retries", 0)) != 0 or int(data.get("substitutions", 0)) != 0:
+        raise ValueError("dataset contract forbids retries/substitutions")
+    return data
+
+
+def build_filelist(exp_dir: Path, *, speaker_id: int = SPEAKER_ID) -> list[str]:
+    """Build the single-speaker F0 filelist expected by the pinned RVC CLI."""
+    exp_dir = Path(exp_dir).resolve()
+    gt = exp_dir / "0_gt_wavs"
+    feature = exp_dir / "3_feature768"
+    f0 = exp_dir / "2a_f0"
+    f0nsf = exp_dir / "2b-f0nsf"
+    names = sorted(p.name for p in gt.glob("*.wav"))
+    if not names:
+        raise ValueError("no preprocessed training WAVs")
+    rows = []
+    for name in names:
+        stem = Path(name).stem
+        paths = [
+            gt / name,
+            feature / f"{stem}.npy",
+            f0 / f"{name}.npy",
+            f0nsf / f"{name}.npy",
+        ]
+        missing = [str(p) for p in paths if not p.is_file()]
+        if missing:
+            raise ValueError(f"incomplete RVC feature tuple for {name}: {missing}")
+        rows.append("|".join([*(str(p) for p in paths), str(speaker_id)]))
+    return rows
+
+
+def mute_rows(rvc_root: Path, *, speaker_id: int = SPEAKER_ID) -> list[str]:
+    root = Path(rvc_root).resolve()
+    line = "|".join(
+        [
+            str(root / "logs/mute/0_gt_wavs/mute32k.wav"),
+            str(root / "logs/mute/3_feature768/mute.npy"),
+            str(root / "logs/mute/2a_f0/mute.wav.npy"),
+            str(root / "logs/mute/2b-f0nsf/mute.wav.npy"),
+            str(speaker_id),
+        ]
+    )
+    return [line, line]
+
+
+def write_filelist(exp_dir: Path, rvc_root: Path) -> Path:
+    rows = build_filelist(exp_dir) + mute_rows(rvc_root)
+    # Upstream WebUI shuffles; the Lab deliberately sorts real rows and appends two
+    # identical mute rows so the handover input is deterministic. Training itself
+    # shuffles samples per epoch from seed 1234.
+    out = Path(exp_dir) / "filelist.txt"
+    out.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return out
+
+
+def expected_training_argv() -> list[str]:
+    return [
+        "train/train.py",
+        "-e", EXPERIMENT,
+        "-sr", "32k",
+        "-f0", "1",
+        "-bs", str(BATCH_SIZE),
+        "-g", str(GPU_ID),
+        "-te", str(TOTAL_EPOCHS),
+        "-se", str(SAVE_EVERY_EPOCHS),
+        "-pg", "assets/pretrained_v2/f0G32k.pth",
+        "-pd", "assets/pretrained_v2/f0D32k.pth",
+        "-l", "1",
+        "-c", "0",
+        "-sw", "1",
+        "-v", VERSION,
+    ]

--- a/tests/test_voice_lab_rvc_gpu_package.py
+++ b/tests/test_voice_lab_rvc_gpu_package.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from audio_engine.voice_lab_rvc_gpu_package import (
+    BATCH_SIZE,
+    MODEL_ASSETS,
+    RVC_CONFIG_BLOB,
+    RVC_REVISION,
+    TOTAL_EPOCHS,
+    build_filelist,
+    expected_training_argv,
+    package_spec,
+    validate_dataset_manifest,
+    write_filelist,
+)
+
+
+class RvcGpuPackageTests(unittest.TestCase):
+    def test_contract_is_frozen_v2_32k_batch4_200_epochs(self):
+        spec = package_spec()
+        self.assertEqual(spec["rvc"]["revision"], RVC_REVISION)
+        self.assertEqual(spec["rvc"]["config_git_blob"], RVC_CONFIG_BLOB)
+        self.assertEqual(BATCH_SIZE, 4)
+        self.assertEqual(TOTAL_EPOCHS, 200)
+        self.assertEqual(spec["training"]["seed"], 1234)
+        self.assertFalse(spec["training"]["parameter_tuning"])
+        self.assertFalse(spec["production_qualified"])
+        self.assertEqual(len(MODEL_ASSETS), 5)
+
+    def test_training_argv_has_no_dynamic_hyperparameters(self):
+        argv = expected_training_argv()
+        self.assertIn("-bs", argv)
+        self.assertEqual(argv[argv.index("-bs") + 1], "4")
+        self.assertEqual(argv[argv.index("-te") + 1], "200")
+        self.assertEqual(argv[argv.index("-f0") + 1], "1")
+        self.assertEqual(argv[argv.index("-v") + 1], "v2")
+        self.assertEqual(argv[argv.index("-c") + 1], "0")
+
+    def test_dataset_manifest_requires_all_machine_gates(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "manifest.json"
+            data = {
+                "status": "dataset-pass",
+                "accepted_duration_seconds": 312.0,
+                "aggregate_wer": 0.012,
+                "expansion_acceptance_rate": 0.90,
+                "retries": 0,
+                "substitutions": 0,
+            }
+            p.write_text(json.dumps(data), encoding="utf-8")
+            self.assertEqual(validate_dataset_manifest(p)["status"], "dataset-pass")
+            data["aggregate_wer"] = 0.051
+            p.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                validate_dataset_manifest(p)
+
+    def test_filelist_matches_rvc_single_speaker_f0_layout(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            exp = root / "logs" / "lucie_rvc_v2_32k"
+            for sub in ("0_gt_wavs", "3_feature768", "2a_f0", "2b-f0nsf"):
+                (exp / sub).mkdir(parents=True, exist_ok=True)
+            for name in ("000.wav", "001.wav"):
+                (exp / "0_gt_wavs" / name).write_bytes(b"wav")
+                (exp / "3_feature768" / f"{Path(name).stem}.npy").write_bytes(b"f")
+                (exp / "2a_f0" / f"{name}.npy").write_bytes(b"f0")
+                (exp / "2b-f0nsf" / f"{name}.npy").write_bytes(b"f0n")
+            rows = build_filelist(exp)
+            self.assertEqual(len(rows), 2)
+            self.assertTrue(rows[0].endswith("|0"))
+            out = write_filelist(exp, root)
+            lines = out.read_text().splitlines()
+            self.assertEqual(len(lines), 4)
+            self.assertEqual(lines[-1], lines[-2])
+            self.assertIn("mute32k.wav", lines[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
FINAL — GPU HANDOVER PACKAGE DRY-RUN PASS, closed unmerged as immutable Lab evidence. No GPU training was executed.

Authoritative package run: `32949671301`; general CI `32949671333` also passed completely.
Artifact: `rvc-gpu-handover-package-dryrun`, id `9599618942`, digest `sha256:b428e033271b3a9065a9f9409b4c8bbc03eb4f0fd65c708c3f4b68af1d37f98b`.
Head: `d88b32321db3af45a2c9c341b09e0716eb45040e`.

Frozen training contract remains unchanged:
- RVC revision `81eed5e8f68b6bed1789f682fe78cdd324495afc`, exact config/source git blobs verified;
- v2 / 32 kHz / F0=1 / RMVPE CUDA / HuBERT v2;
- native seed 1234, batch 4, one GPU id 0, 200 epochs, save every 25, cache off;
- no auto-batch, hyperparameter tuning or fallback;
- exactly one CUDA GPU with >=10 GiB VRAM;
- bootstrap model assets content-hashed before use;
- output remains `gpu-training-complete-unqualified` until the existing French/identity/emotion killer evaluates it.

Dataset admission remains strict and machine-only: `dataset-pass`, accepted duration >=300 s, aggregate WER <=0.05, expansion acceptance >=85%, zero retries/substitutions.

The first dry-run failure was infrastructure-only: the qualified pilot artifact stores its manifest at `qualified/manifest.json`, not the assumed artifact root. The correction changed only that artifact path. The authoritative run then proved:
- syntax/unit/package contract PASS;
- exact pinned RVC source + CLI surface PASS;
- the qualified 51.12 s pilot is correctly REJECTED as insufficient for GPU training;
- a positive `dataset-pass` fixture is accepted;
- no hidden training knobs in the execution script;
- artifact upload PASS.

This package is now ready to consume the separately qualified 5-minute Lucie corpus once PR #130 reaches `dataset-pass`. No human gate, Pages, Edge or Production change.