### PR TITLE
LAB: MeanVC2 CPU resource preflight

### DIFF
--- a/.github/workflows/voice-casting-meanvc2-resource-preflight.yml
+++ b/.github/workflows/voice-casting-meanvc2-resource-preflight.yml
@@ -1,0 +1,222 @@
+name: Voice Casting MeanVC2 CPU Resource Preflight
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/voice-casting-meanvc2-resource-preflight.yml
+      - docs/lab/MEANVC2_CPU_RESOURCE_PREFLIGHT.md
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  MEANVC2_REV: 0d39c8ae416a37edb9884db67334e4b9d0c3e308
+  HF_REPO: ASLP-lab/MeanVC2
+  HF_REV: 4a73815c6b392bcb435769f69d7f5fdeccbc39dd
+  VC_SHA256: 04ea21a4fb55400469e6004ae842c3e7f059f759e92946fb95123418cad5d818
+  VC_SIZE: "70839448"
+  VOCOS_SHA256: df1f2ba9f7ac35c96832579421ee1ed913a68c3a1d2f8a6536739f902f194a93
+  VOCOS_SIZE: "33223674"
+  WAVLM_URL: https://github.com/microsoft/unilm/releases/download/wavlm/WavLM-Large.pt
+  WAVLM_FINETUNE_GDRIVE_ID: 1-aE1NfzpRCLxA4GUxX9ITI3F9LlbtEGP
+  PIP_NO_CACHE_DIR: "1"
+  HF_HUB_DISABLE_TELEMETRY: "1"
+  OMP_NUM_THREADS: "2"
+  MKL_NUM_THREADS: "2"
+
+jobs:
+  resource-preflight:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Freeze resource contract before external downloads
+        run: |
+          mkdir -p evidence
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          contract = {
+            "status": "resource-contract-frozen",
+            "science_authorized": False,
+            "render_authorized": False,
+            "device": "cpu",
+            "meanvc2_revision": "0d39c8ae416a37edb9884db67334e4b9d0c3e308",
+            "hf_revision": "4a73815c6b392bcb435769f69d7f5fdeccbc39dd",
+            "model": "120ms+40ms",
+            "future_science": {"chunk_size": 12, "steps": 3, "seed": 0},
+            "forbidden": ["cuda", "paid_gpu", "private_token", "manual_download", "user_supplied_file", "scientific_render"]
+          }
+          Path("evidence/contract.json").write_text(json.dumps(contract, indent=2), encoding="utf-8")
+          print(json.dumps(contract, indent=2))
+          PY
+
+      - name: Free runner disk
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          df -h /
+
+      - name: Fetch exact MeanVC2 source and verify declared license provenance
+        run: |
+          git init MeanVC2
+          git -C MeanVC2 remote add origin https://github.com/ASLP-lab/MeanVC2.git
+          git -C MeanVC2 fetch --depth=1 origin "$MEANVC2_REV"
+          git -C MeanVC2 checkout --detach FETCH_HEAD
+          test "$(git -C MeanVC2 rev-parse HEAD)" = "$MEANVC2_REV"
+          grep -q "License-Apache%202.0" MeanVC2/README.md
+          grep -q "released under the \[Apache License 2.0\]" MeanVC2/README.md
+          test ! -e MeanVC2/LICENSE
+          echo "LAB_LICENSE_PROVENANCE=README_AND_HF_MODEL_CARD_ONLY" | tee evidence/license.txt
+
+      - name: Install minimal pinned CPU inference runtime
+        run: |
+          python -m pip install --disable-pip-version-check --index-url https://download.pytorch.org/whl/cpu torch==2.5.1 torchaudio==2.5.1
+          python -m pip install --disable-pip-version-check \
+            'numpy>=1.26,<2.1' soundfile librosa soxr safetensors \
+            einops==0.8.0 x-transformers==2.2.11 torchdiffeq==0.2.5 \
+            huggingface-hub==0.36.0 gdown==5.2.0 omegaconf==2.3.0 \
+            s3prl==0.4.18
+          python - <<'PY'
+          import torch, torchaudio, numpy, soundfile, librosa, safetensors, s3prl
+          assert not torch.cuda.is_available()
+          print("CPU_RUNTIME_PASS", torch.__version__, torchaudio.__version__, numpy.__version__)
+          PY
+
+      - name: Download exact public MeanVC2 quality assets
+        run: |
+          mkdir -p MeanVC2/preprocess/ckpts MeanVC2/ckpts/pretrained_models MeanVC2/ckpts/vocos
+          python - <<'PY'
+          import os, shutil
+          from pathlib import Path
+          from huggingface_hub import hf_hub_download
+          repo=os.environ['HF_REPO']; rev=os.environ['HF_REV']
+          mapping={
+            'meanvc2_120ms_40ms.safetensors':'MeanVC2/ckpts/pretrained_models/meanvc2_120ms_40ms.safetensors',
+            'fastu2pp_160ms.pt':'MeanVC2/preprocess/ckpts/fastu2pp_160ms.pt',
+            'vocos.pt':'MeanVC2/ckpts/vocos/vocos.pt',
+          }
+          for name,dst in mapping.items():
+            src=hf_hub_download(repo_id=repo, revision=rev, filename=name)
+            Path(dst).parent.mkdir(parents=True,exist_ok=True)
+            shutil.copy2(src,dst)
+            print(name, '->', dst)
+          PY
+          test "$(stat -c%s MeanVC2/ckpts/pretrained_models/meanvc2_120ms_40ms.safetensors)" = "$VC_SIZE"
+          test "$(sha256sum MeanVC2/ckpts/pretrained_models/meanvc2_120ms_40ms.safetensors | cut -d' ' -f1)" = "$VC_SHA256"
+          test "$(stat -c%s MeanVC2/ckpts/vocos/vocos.pt)" = "$VOCOS_SIZE"
+          test "$(sha256sum MeanVC2/ckpts/vocos/vocos.pt | cut -d' ' -f1)" = "$VOCOS_SHA256"
+
+      - name: Download public WavLM speaker assets without account or token
+        run: |
+          curl --fail --location --retry 3 --retry-delay 2 "$WAVLM_URL" -o MeanVC2/preprocess/ckpts/wavlm_large.pt
+          gdown --id "$WAVLM_FINETUNE_GDRIVE_ID" -O MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth
+          test -s MeanVC2/preprocess/ckpts/wavlm_large.pt
+          test -s MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth
+
+      - name: Freeze exact asset hashes and sizes before any scientific render
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          files={
+            'vc_model':'MeanVC2/ckpts/pretrained_models/meanvc2_120ms_40ms.safetensors',
+            'asr_160ms':'MeanVC2/preprocess/ckpts/fastu2pp_160ms.pt',
+            'vocos':'MeanVC2/ckpts/vocos/vocos.pt',
+            'wavlm_large':'MeanVC2/preprocess/ckpts/wavlm_large.pt',
+            'wavlm_finetuned':'MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth',
+          }
+          out={}
+          for key,name in files.items():
+            p=Path(name); h=hashlib.sha256()
+            with p.open('rb') as f:
+              for block in iter(lambda:f.read(1024*1024),b''):h.update(block)
+            out[key]={'path':name,'bytes':p.stat().st_size,'sha256':h.hexdigest()}
+          assert out['vc_model']['sha256']==os.environ['VC_SHA256']
+          assert out['vocos']['sha256']==os.environ['VOCOS_SHA256']
+          Path('evidence/assets.json').write_text(json.dumps(out,indent=2),encoding='utf-8')
+          print(json.dumps(out,indent=2))
+          PY
+
+      - name: Prove MeanVC2 components load on standard CPU runner
+        run: |
+          /usr/bin/time -v -o evidence/cpu-load-time.txt python - <<'PY'
+          import json, os, sys, torch
+          from pathlib import Path
+          root=Path('MeanVC2').resolve()
+          os.chdir(root)
+          sys.path.insert(0,str(root))
+          sys.path.insert(0,str(root/'src/infer'))
+          assert not torch.cuda.is_available()
+          asr=torch.jit.load('preprocess/ckpts/fastu2pp_160ms.pt',map_location='cpu').eval()
+          vocos=torch.jit.load('ckpts/vocos/vocos.pt',map_location='cpu').eval()
+          from preprocess.models.ecapa_tdnn import ECAPA_TDNN_SMALL
+          spk=ECAPA_TDNN_SMALL(feat_dim=1024,feat_type='wavlm_large')
+          state=torch.load('preprocess/ckpts/wavlm_large_finetune.pth',map_location='cpu')
+          missing,unexpected=spk.load_state_dict(state['model'],strict=False)
+          spk=spk.cpu().eval()
+          from dit_kvcache import DiT
+          from src.model.utils import load_checkpoint
+          cfg=json.loads(Path('src/config/config_120ms_40ms.json').read_text())
+          vc=DiT(**cfg['model']).cpu()
+          vc=load_checkpoint(vc,'ckpts/pretrained_models/meanvc2_120ms_40ms.safetensors',device='cpu',use_ema=True).float().eval()
+          report={
+            'status':'cpu-components-load-pass',
+            'cuda_available':torch.cuda.is_available(),
+            'asr_loaded':asr is not None,
+            'vocos_loaded':vocos is not None,
+            'speaker_loaded':spk is not None,
+            'vc_loaded':vc is not None,
+            'speaker_missing_keys':list(missing),
+            'speaker_unexpected_keys':list(unexpected),
+            'scientific_render':False,
+          }
+          Path('../evidence/cpu-load.json').write_text(json.dumps(report,indent=2),encoding='utf-8')
+          print(json.dumps(report,indent=2))
+          PY
+
+      - name: Record final resource verdict
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          assets=Path('evidence/assets.json')
+          load=Path('evidence/cpu-load.json')
+          ok=assets.is_file() and load.is_file() and json.loads(load.read_text()).get('status')=='cpu-components-load-pass'
+          out={
+            'status':'resource-preflight-pass' if ok else 'resource-preflight-incomplete',
+            'scientific_render':False,
+            'science_authorized_next':bool(ok),
+            'next_gate':'one immutable panic--lucie MeanVC2 CPU smoke' if ok else 'none; diagnose infrastructure/resource only',
+          }
+          Path('evidence/final.json').write_text(json.dumps(out,indent=2),encoding='utf-8')
+          print(json.dumps(out,indent=2))
+          PY
+
+      - name: Upload resource evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: meanvc2-cpu-resource-preflight
+          path: evidence/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Surface resource verdict
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          status=json.loads(Path('evidence/final.json').read_text())['status']
+          if status!='resource-preflight-pass': raise SystemExit(f'resource verdict: {status}')
+          print('MEANVC2_RESOURCE_PREFLIGHT_PASS')
+          PY

--- a/.github/workflows/voice-casting-meanvc2-resource-preflight.yml
+++ b/.github/workflows/voice-casting-meanvc2-resource-preflight.yml
@@ -18,10 +18,16 @@ env:
   HF_REV: 4a73815c6b392bcb435769f69d7f5fdeccbc39dd
   VC_SHA256: 04ea21a4fb55400469e6004ae842c3e7f059f759e92946fb95123418cad5d818
   VC_SIZE: "70839448"
+  ASR_SHA256: 9a372c1b7178f564a15da1cd36901d7d0c9081a2fabf53cb6cc0d971deca4928
+  ASR_SIZE: "246275643"
   VOCOS_SHA256: df1f2ba9f7ac35c96832579421ee1ed913a68c3a1d2f8a6536739f902f194a93
   VOCOS_SIZE: "33223674"
   WAVLM_GDRIVE_ID: 12-cB34qCTvByWT-QtOcZaqwwO21FLSqU
+  WAVLM_SHA256: 6fb4b3c3e6aa567f0a997b30855859cb81528ee8078802af439f7b2da0bf100f
+  WAVLM_SIZE: "1261965425"
   WAVLM_FINETUNE_GDRIVE_ID: 1-aE1NfzpRCLxA4GUxX9ITI3F9LlbtEGP
+  WAVLM_FINETUNE_SHA256: 51f07e3b94d9e0262a6a675ef5a087be3dd09e8c62e9d886827f44f82fe7f94b
+  WAVLM_FINETUNE_SIZE: "1301926579"
   PIP_NO_CACHE_DIR: "1"
   HF_HUB_DISABLE_TELEMETRY: "1"
   OMP_NUM_THREADS: "2"
@@ -83,11 +89,11 @@ jobs:
             'numpy>=1.26,<2.1' soundfile librosa soxr safetensors \
             einops==0.8.0 x-transformers==2.2.11 torchdiffeq==0.2.5 \
             huggingface-hub==0.36.0 gdown==5.2.0 omegaconf==2.3.0 \
-            s3prl==0.4.18
+            s3prl==0.4.18 matplotlib==3.9.2
           python - <<'PY'
-          import torch, torchaudio, numpy, soundfile, librosa, safetensors, s3prl
+          import torch, torchaudio, numpy, soundfile, librosa, safetensors, s3prl, matplotlib
           assert not torch.cuda.is_available()
-          print("CPU_RUNTIME_PASS", torch.__version__, torchaudio.__version__, numpy.__version__)
+          print("CPU_RUNTIME_PASS", torch.__version__, torchaudio.__version__, numpy.__version__, matplotlib.__version__)
           PY
 
       - name: Download exact public MeanVC2 quality assets
@@ -111,15 +117,19 @@ jobs:
           PY
           test "$(stat -c%s MeanVC2/ckpts/pretrained_models/meanvc2_120ms_40ms.safetensors)" = "$VC_SIZE"
           test "$(sha256sum MeanVC2/ckpts/pretrained_models/meanvc2_120ms_40ms.safetensors | cut -d' ' -f1)" = "$VC_SHA256"
+          test "$(stat -c%s MeanVC2/preprocess/ckpts/fastu2pp_160ms.pt)" = "$ASR_SIZE"
+          test "$(sha256sum MeanVC2/preprocess/ckpts/fastu2pp_160ms.pt | cut -d' ' -f1)" = "$ASR_SHA256"
           test "$(stat -c%s MeanVC2/ckpts/vocos/vocos.pt)" = "$VOCOS_SIZE"
           test "$(sha256sum MeanVC2/ckpts/vocos/vocos.pt | cut -d' ' -f1)" = "$VOCOS_SHA256"
 
       - name: Download official public WavLM speaker assets without account or token
         run: |
-          gdown --id "$WAVLM_GDRIVE_ID" -O MeanVC2/preprocess/ckpts/wavlm_large.pt
-          gdown --id "$WAVLM_FINETUNE_GDRIVE_ID" -O MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth
-          test -s MeanVC2/preprocess/ckpts/wavlm_large.pt
-          test -s MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth
+          gdown "$WAVLM_GDRIVE_ID" -O MeanVC2/preprocess/ckpts/wavlm_large.pt
+          gdown "$WAVLM_FINETUNE_GDRIVE_ID" -O MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth
+          test "$(stat -c%s MeanVC2/preprocess/ckpts/wavlm_large.pt)" = "$WAVLM_SIZE"
+          test "$(sha256sum MeanVC2/preprocess/ckpts/wavlm_large.pt | cut -d' ' -f1)" = "$WAVLM_SHA256"
+          test "$(stat -c%s MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth)" = "$WAVLM_FINETUNE_SIZE"
+          test "$(sha256sum MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth | cut -d' ' -f1)" = "$WAVLM_FINETUNE_SHA256"
 
       - name: Freeze exact asset hashes and sizes before any scientific render
         run: |
@@ -133,14 +143,20 @@ jobs:
             'wavlm_large':'MeanVC2/preprocess/ckpts/wavlm_large.pt',
             'wavlm_finetuned':'MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth',
           }
+          expected={
+            'vc_model':(int(os.environ['VC_SIZE']),os.environ['VC_SHA256']),
+            'asr_160ms':(int(os.environ['ASR_SIZE']),os.environ['ASR_SHA256']),
+            'vocos':(int(os.environ['VOCOS_SIZE']),os.environ['VOCOS_SHA256']),
+            'wavlm_large':(int(os.environ['WAVLM_SIZE']),os.environ['WAVLM_SHA256']),
+            'wavlm_finetuned':(int(os.environ['WAVLM_FINETUNE_SIZE']),os.environ['WAVLM_FINETUNE_SHA256']),
+          }
           out={}
           for key,name in files.items():
             p=Path(name); h=hashlib.sha256()
             with p.open('rb') as f:
-              for block in iter(lambda:f.read(1024*1024),b''):h.update(block)
+              for block in iter(lambda:f.read(1024*1024),b''): h.update(block)
             out[key]={'path':name,'bytes':p.stat().st_size,'sha256':h.hexdigest()}
-          assert out['vc_model']['sha256']==os.environ['VC_SHA256']
-          assert out['vocos']['sha256']==os.environ['VOCOS_SHA256']
+            assert (out[key]['bytes'],out[key]['sha256'])==expected[key], (key,out[key],expected[key])
           Path('evidence/assets.json').write_text(json.dumps(out,indent=2),encoding='utf-8')
           print(json.dumps(out,indent=2))
           PY

--- a/.github/workflows/voice-casting-meanvc2-resource-preflight.yml
+++ b/.github/workflows/voice-casting-meanvc2-resource-preflight.yml
@@ -28,6 +28,8 @@ env:
   WAVLM_FINETUNE_GDRIVE_ID: 1-aE1NfzpRCLxA4GUxX9ITI3F9LlbtEGP
   WAVLM_FINETUNE_SHA256: 51f07e3b94d9e0262a6a675ef5a087be3dd09e8c62e9d886827f44f82fe7f94b
   WAVLM_FINETUNE_SIZE: "1301926579"
+  MODEL_INIT_ORIGINAL_SHA256: 8d2c553d08d4b44d8ad579e8da0555885bffbc86c0960fe2f86c197ac5bf06a3
+  MODEL_INIT_INFERENCE_SHA256: 6a2bdf9a11188869466998429c3df620d31ec499ac9c407946647567c1891ca1
   PIP_NO_CACHE_DIR: "1"
   HF_HUB_DISABLE_TELEMETRY: "1"
   OMP_NUM_THREADS: "2"
@@ -81,6 +83,40 @@ jobs:
           grep -q "released under the \[Apache License 2.0\]" MeanVC2/README.md
           test ! -e MeanVC2/LICENSE
           echo "LAB_LICENSE_PROVENANCE=README_AND_HF_MODEL_CARD_ONLY" | tee evidence/license.txt
+
+      - name: Apply frozen inference-only packaging patch
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          p=Path('MeanVC2/src/model/__init__.py')
+          raw=p.read_bytes()
+          before=hashlib.sha256(raw).hexdigest()
+          if before != os.environ['MODEL_INIT_ORIGINAL_SHA256']:
+              raise SystemExit(f'unexpected upstream src/model/__init__.py SHA: {before}')
+          text=raw.decode('utf-8')
+          old='from src.model.trainer import Trainer\n\n__all__ = ["CFM", "UNetT", "DiT", "MMDiT", "Trainer"]\n'
+          new='\n__all__ = ["CFM", "UNetT", "DiT", "MMDiT"]\n'
+          if old not in text:
+              raise SystemExit('expected Trainer-only package import block not found')
+          text=text.replace(old,new,1)
+          p.write_text(text,encoding='utf-8')
+          after=hashlib.sha256(p.read_bytes()).hexdigest()
+          if after != os.environ['MODEL_INIT_INFERENCE_SHA256']:
+              raise SystemExit(f'unexpected patched src/model/__init__.py SHA: {after}')
+          report={
+            'status':'inference-packaging-patch-pass',
+            'upstream_file':'src/model/__init__.py',
+            'before_sha256':before,
+            'after_sha256':after,
+            'removed_only':'Trainer package import/export',
+            'model_math_changed':False,
+            'weights_changed':False,
+            'scientific_parameters_changed':False,
+          }
+          Path('evidence/inference-packaging-patch.json').write_text(json.dumps(report,indent=2),encoding='utf-8')
+          print(json.dumps(report,indent=2))
+          PY
 
       - name: Install minimal pinned CPU inference runtime
         run: |
@@ -206,11 +242,13 @@ jobs:
           from pathlib import Path
           assets=Path('evidence/assets.json')
           load=Path('evidence/cpu-load.json')
-          ok=assets.is_file() and load.is_file() and json.loads(load.read_text()).get('status')=='cpu-components-load-pass'
+          patch=Path('evidence/inference-packaging-patch.json')
+          ok=assets.is_file() and patch.is_file() and load.is_file() and json.loads(load.read_text()).get('status')=='cpu-components-load-pass'
           out={
             'status':'resource-preflight-pass' if ok else 'resource-preflight-incomplete',
             'scientific_render':False,
             'science_authorized_next':bool(ok),
+            'inference_packaging_patch':'Trainer import/export removed only',
             'next_gate':'one immutable panic--lucie MeanVC2 CPU smoke' if ok else 'none; diagnose infrastructure/resource only',
           }
           Path('evidence/final.json').write_text(json.dumps(out,indent=2),encoding='utf-8')

--- a/.github/workflows/voice-casting-meanvc2-resource-preflight.yml
+++ b/.github/workflows/voice-casting-meanvc2-resource-preflight.yml
@@ -20,7 +20,7 @@ env:
   VC_SIZE: "70839448"
   VOCOS_SHA256: df1f2ba9f7ac35c96832579421ee1ed913a68c3a1d2f8a6536739f902f194a93
   VOCOS_SIZE: "33223674"
-  WAVLM_URL: https://github.com/microsoft/unilm/releases/download/wavlm/WavLM-Large.pt
+  WAVLM_GDRIVE_ID: 12-cB34qCTvByWT-QtOcZaqwwO21FLSqU
   WAVLM_FINETUNE_GDRIVE_ID: 1-aE1NfzpRCLxA4GUxX9ITI3F9LlbtEGP
   PIP_NO_CACHE_DIR: "1"
   HF_HUB_DISABLE_TELEMETRY: "1"
@@ -114,9 +114,9 @@ jobs:
           test "$(stat -c%s MeanVC2/ckpts/vocos/vocos.pt)" = "$VOCOS_SIZE"
           test "$(sha256sum MeanVC2/ckpts/vocos/vocos.pt | cut -d' ' -f1)" = "$VOCOS_SHA256"
 
-      - name: Download public WavLM speaker assets without account or token
+      - name: Download official public WavLM speaker assets without account or token
         run: |
-          curl --fail --location --retry 3 --retry-delay 2 "$WAVLM_URL" -o MeanVC2/preprocess/ckpts/wavlm_large.pt
+          gdown --id "$WAVLM_GDRIVE_ID" -O MeanVC2/preprocess/ckpts/wavlm_large.pt
           gdown --id "$WAVLM_FINETUNE_GDRIVE_ID" -O MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth
           test -s MeanVC2/preprocess/ckpts/wavlm_large.pt
           test -s MeanVC2/preprocess/ckpts/wavlm_large_finetune.pth

--- a/docs/lab/MEANVC2_CPU_RESOURCE_PREFLIGHT.md
+++ b/docs/lab/MEANVC2_CPU_RESOURCE_PREFLIGHT.md
@@ -1,0 +1,62 @@
+# MeanVC2 CPU resource preflight
+
+Status: Lab-only infrastructure/resource gate. This document does not authorize a scientific voice-conversion result, human listening, Production, Edge, or Pages changes.
+
+## Why this gate exists
+
+The previous RVC path reached a CUDA boundary that was not checked early enough. MeanVC2 is therefore not allowed to enter a scientific killer until the exact next experiment is proven executable using project-accessible resources.
+
+## Frozen upstream
+
+- code repository: `ASLP-lab/MeanVC2`
+- Git revision: `0d39c8ae416a37edb9884db67334e4b9d0c3e308`
+- upstream declares Apache-2.0 in the pinned README and model card; the Git repository does not contain a standalone LICENSE file, so this remains Lab-only provenance until clarified.
+- Hugging Face model repository: `ASLP-lab/MeanVC2`
+- pinned model snapshot: `4a73815c6b392bcb435769f69d7f5fdeccbc39dd`
+- quality model: `meanvc2_120ms_40ms.safetensors`
+- published model SHA-256: `04ea21a4fb55400469e6004ae842c3e7f059f759e92946fb95123418cad5d818`
+- published model size: `70839448` bytes
+- published vocoder SHA-256: `df1f2ba9f7ac35c96832579421ee1ed913a68c3a1d2f8a6536739f902f194a93`
+- published vocoder size: `33223674` bytes
+- ASR asset: `fastu2pp_160ms.pt`; exact SHA is frozen from the first successful resource preflight before any scientific render.
+- WavLM base: Microsoft public `WavLM-Large.pt`; exact SHA is frozen from the first successful resource preflight.
+- WavLM ECAPA fine-tune public Google Drive file id: `1-aE1NfzpRCLxA4GUxX9ITI3F9LlbtEGP`; exact SHA is frozen from the first successful resource preflight.
+
+## Resource contract
+
+The resource preflight must run on a standard GitHub-hosted CPU runner. It may download public artifacts but may not require:
+
+- CUDA or another accelerator;
+- a paid GPU service;
+- a private Hugging Face token;
+- a Google account;
+- a user-supplied file;
+- manual browser interaction.
+
+It must prove all of the following before scientific work:
+
+1. the exact Git revision is available;
+2. the exact pinned Hugging Face VC model and vocoder are downloadable and match the published hashes;
+3. the 160 ms Fast-U2++ asset is downloadable and hashed;
+4. WavLM-Large is downloadable from Microsoft's public release and hashed;
+5. the WavLM fine-tuned speaker checkpoint is downloadable non-interactively and hashed;
+6. the CPU PyTorch runtime and MeanVC2 E2E imports load successfully;
+7. the JIT ASR and Vocos files load on CPU;
+8. the speaker encoder can be instantiated on CPU with the downloaded WavLM assets;
+9. peak disk/RAM/runtime evidence is retained.
+
+Any failure here is infrastructure/resource evidence only. It cannot be interpreted as a voice-quality failure and cannot trigger parameter tuning.
+
+## Scientific contract reserved for the next gate
+
+Only a successful resource preflight may authorize one immutable killer cell:
+
+- source: existing Claire panic WAV, SHA-256 `ac92fd1f8346b981ac7518e1e698cf8b1c31a96dff069ad60a2d017a17ff9d7f`;
+- target: existing Lucie reference WAV, SHA-256 `9e5ff59c1b2993b249851bfd3a9f8e78047fd5afd93b034392df1977ae54c822`;
+- MeanVC2 quality preset `120ms`, upstream chunk size `12`, `steps=3`;
+- device `cpu`;
+- seed `0`, fixed before rendering;
+- no training, finetuning, retries, alternative references, substitutions, or parameter search;
+- gate order: technical -> independent WeSpeaker target identity -> exact Whisper French no-worse-than immutable source -> source-relative SUPERB panic preservation.
+
+If that future one-cell smoke fails any scientific gate, direct zero-shot MeanVC2 is retired without tuning. If it passes all gates, only the exact four-cell matrix is authorized next.


### PR DESCRIPTION
Lab-only RESOURCE ADMISSIBILITY evidence. No scientific voice conversion was executed in this PR.

Purpose: prevent a repeat of the RVC CUDA mistake by proving the complete next MeanVC2 experiment is executable on standard project-accessible CPU resources before any killer render.

Frozen upstream:
- MeanVC2 Git `0d39c8ae416a37edb9884db67334e4b9d0c3e308`;
- HF snapshot `4a73815c6b392bcb435769f69d7f5fdeccbc39dd`;
- quality model 120ms+40ms.

AUTHORITATIVE RESOURCE PASS
- run: `32959582512`
- head: `32eb0acd33cc4ea412a01fd5de23d86a6cdbf60e`
- artifact: `meanvc2-cpu-resource-preflight`
- artifact id: `9603417801`
- artifact digest: `sha256:4d0a244604fdde52059ee44bd2abed8956834c845a0d109526473079056ea6fe`
- final status: `resource-preflight-pass`
- CUDA available: false
- ASR loaded: true
- Vocos loaded: true
- WavLM/ECAPA speaker encoder loaded: true
- MeanVC2 DiT loaded: true
- component-load wall time: 10.38 s
- max RSS during component load: 3,504,752 KiB (~3.34 GiB)
- swaps: 0

Frozen assets:
- VC `meanvc2_120ms_40ms.safetensors`: 70,839,448 bytes, SHA-256 `04ea21a4fb55400469e6004ae842c3e7f059f759e92946fb95123418cad5d818`
- ASR `fastu2pp_160ms.pt`: 246,275,643 bytes, SHA-256 `9a372c1b7178f564a15da1cd36901d7d0c9081a2fabf53cb6cc0d971deca4928`
- Vocos `vocos.pt`: 33,223,674 bytes, SHA-256 `df1f2ba9f7ac35c96832579421ee1ed913a68c3a1d2f8a6536739f902f194a93`
- WavLM Large: 1,261,965,425 bytes, SHA-256 `6fb4b3c3e6aa567f0a997b30855859cb81528ee8078802af439f7b2da0bf100f`
- WavLM fine-tuned speaker checkpoint: 1,301,926,579 bytes, SHA-256 `51f07e3b94d9e0262a6a675ef5a087be3dd09e8c62e9d886827f44f82fe7f94b`

Resource-only harness history:
- R1: obsolete Microsoft GitHub WavLM URL returned 404; replaced only by Microsoft's official public Google Drive mirror.
- R2: component import reached `src.model.utils` then lacked `matplotlib`; added the inference dependency only.
- R3: package `src.model.__init__` imported the unrelated training `Trainer`, causing missing `wandb` and an unnecessary training dependency cascade.
- R4: after exact upstream-file SHA verification, an inference-only packaging patch removed only the `Trainer` import/export. Original SHA `8d2c553d08d4b44d8ad579e8da0555885bffbc86c0960fe2f86c197ac5bf06a3`; patched SHA `6a2bdf9a11188869466998429c3df620d31ec499ac9c407946647567c1891ca1`. Model math, weights and scientific parameters unchanged.

Speaker checkpoint load had zero missing keys and one unexpected training-only key: `loss_calculator.projection.weight`.

Licensing note: pinned Git README and HF model card declare Apache-2.0, but the Git repository lacks a standalone LICENSE file. Accepted for Lab research only; not sufficient by itself for Production promotion.

RESOURCE VERDICT: PASS. The complete next experiment is executable on a standard GitHub-hosted CPU runner without CUDA, paid GPU, private token, Google account, manual browser action, or user-supplied file.

This pass authorizes only the already preregistered one-cell MeanVC2 CPU killer: immutable Claire panic -> Lucie, preset 120ms, chunk 12, steps 3, seed 0, no training/finetuning/retry/substitution/reference search/tuning. Machine gate order remains technical -> independent WeSpeaker identity -> Whisper French no-worse-than immutable source -> source-relative SUPERB panic preservation.

Closed unmerged as immutable resource evidence. Production, Edge and Pages remain untouched.