### PR TITLE
docs: publish Production Director interface and recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ audio-engine capabilities --category acoustic_spaces
 
 The sound catalog answers which validated audio assets exist; the capability catalog answers what the renderer can do with them.
 
-See [`docs/EFFECTS.md`](docs/EFFECTS.md), [`docs/CONTRACT.md`](docs/CONTRACT.md), [`docs/SOUNDS.md`](docs/SOUNDS.md), and [`docs/VOICES.md`](docs/VOICES.md).
+See [`docs/EFFECTS.md`](docs/EFFECTS.md), [`docs/CONTRACT.md`](docs/CONTRACT.md), [`docs/SOUNDS.md`](docs/SOUNDS.md), and [`docs/VOICES.md`](docs/VOICES.md). Production-director consumers should also read [`docs/PRODUCTION_DIRECTORS.md`](docs/PRODUCTION_DIRECTORS.md) and the supported [`docs/PRODUCTION_RECIPES.md`](docs/PRODUCTION_RECIPES.md).
 
 ## Program schemas
 

--- a/docs/PRODUCTION_DIRECTORS.md
+++ b/docs/PRODUCTION_DIRECTORS.md
@@ -52,7 +52,7 @@ Use:
 
 - `capabilities` for supported Program schema versions, acoustic spaces, sound roles, transition defaults, placement, ducking and hard limits;
 - `voices` for validated voice presets and stable casting metadata;
-- `sounds` for validated production-ready ambience/event resources.
+- `sounds` for validated production-ready ambience/event resources. At the PROD-WP-001 baseline the built-in catalog is empty, so a director cannot assume any reusable sound id exists.
 
 The machine-readable capability catalog remains `src/audio_engine/capabilities.json`. Do not create or hard-code a competing catalog in consumer applications.
 
@@ -101,7 +101,7 @@ audio-engine timing PROGRAM.json --out output
 
 `timing` gives measured cached durations when available and calibrated estimates otherwise. Estimates are design guidance, not final timing authority.
 
-A director should stop before full rendering when the Program itself is invalid or requests a capability outside the installed catalog.
+A director should stop before full rendering when the Program itself is invalid or requests a capability outside the installed catalog. Sound semantics can still be authored with consumer-owned local relative files, but those files must be present and governed by the consumer before render.
 
 ## Representative probe
 

--- a/docs/PRODUCTION_DIRECTORS.md
+++ b/docs/PRODUCTION_DIRECTORS.md
@@ -1,0 +1,202 @@
+# Production Director integration
+
+This document defines how an Audioguide or Audiobook production director should drive Audio Engine without becoming coupled to renderer internals.
+
+## Boundary
+
+Audio Engine does **not** own the director's high-level Production Plan.
+
+A consumer may keep a richer plan containing story structure, editorial priorities, scene goals, optional material and fallback policy. Before rendering, the director/compiler reduces that plan to the public Audio Engine Program contract documented in [CONTRACT.md](CONTRACT.md).
+
+```text
+consumer story / chapter
+        |
+        v
+Production Director
+        |
+        | consults
+        +-------------------+-------------------+
+        |                   |                   |
+        v                   v                   v
+audio-engine           audio-engine         audio-engine
+capabilities             voices               sounds
+        \                   |                   /
+         \                  |                  /
+          +-------- director/compiler --------+
+                           |
+                           v
+                  Program schema v1..v6
+                           |
+                      validate / timing
+                           |
+                    targeted preview
+                           |
+                         render
+                           |
+                  manifest + audio assets
+```
+
+The Program schema is the executable contract. Product-specific authoring logic stays outside the engine.
+
+## Discover before authoring
+
+A director must discover the installed renderer rather than assume a larger palette:
+
+```bash
+audio-engine capabilities
+audio-engine voices
+audio-engine sounds
+```
+
+Use:
+
+- `capabilities` for supported Program schema versions, acoustic spaces, sound roles, transition defaults, placement, ducking and hard limits;
+- `voices` for validated voice presets and stable casting metadata;
+- `sounds` for validated production-ready ambience/event resources.
+
+The machine-readable capability catalog remains `src/audio_engine/capabilities.json`. Do not create or hard-code a competing catalog in consumer applications.
+
+## Compile the Production Plan
+
+A consumer Production Plan may contain concepts that are useful to a director but are not Audio Engine fields, for example:
+
+- narrative arc;
+- scene objective;
+- target episode duration;
+- editorial priority;
+- material that may be omitted;
+- consumer-specific fallback policy;
+- location or navigation metadata for an audioguide;
+- chapter/book continuity metadata for an audiobook.
+
+The compiler must resolve those concepts **before** calling Audio Engine.
+
+Do not copy unknown director fields into the Program JSON. Audio Engine should receive only declared contract fields.
+
+## Choose the lowest sufficient schema
+
+Prefer the smallest schema version that expresses the intended production:
+
+| Need | Minimum schema |
+| --- | ---: |
+| Narration | v1 |
+| Actor placement / legacy ambience | v2 |
+| Deterministic bed, layers, punctual events | v3 |
+| Acoustic spaces / narration-free scene event | v4 |
+| Bridge with fixed carry under speech | v5 |
+| Bridge carried through measured spoken segment(s) | v6 |
+
+Do not upgrade merely because a newer version exists.
+
+## Fail cheap
+
+Before expensive synthesis, use deterministic checks first:
+
+```bash
+audio-engine validate PROGRAM.json
+audio-engine timing PROGRAM.json --out output
+```
+
+`validate` rejects invalid contract combinations.
+
+`timing` gives measured cached durations when available and calibrated estimates otherwise. Estimates are design guidance, not final timing authority.
+
+A director should stop before full rendering when the Program itself is invalid or requests a capability outside the installed catalog.
+
+## Representative probe
+
+For sound-directed programs, audition risky transitions before a full batch:
+
+```bash
+audio-engine preview PROGRAM.json --out output --event 1
+```
+
+The director should select the event(s) with the highest structural or artistic risk rather than mechanically previewing the first event.
+
+Typical high-risk probes are:
+
+- a `scene` event with a tight narration-free window;
+- a `bridge` that must hand attention back to speech;
+- a dense texture/event combination;
+- a short acoustic accent;
+- a transition whose source asset may be too short.
+
+Preview reuses stage caches, so unchanged speech should not be synthesized again during later mixing changes.
+
+## Commit late, finish robustly
+
+The recommended production flow is:
+
+```text
+capability discovery
+        |
+director compile
+        |
+validate -------- FAIL -> stop cheaply
+        |
+timing / risk selection
+        |
+representative preview -- blocker -> stop cheaply
+        |
+======== commit to full render ========
+        |
+full render / batch
+        |
+manifest inspection / automatic QA
+        |
+human listening
+```
+
+After the commit point, non-essential product concerns should normally become warnings or consumer-side fallbacks rather than reasons to discard otherwise valid rendered units. Audio Engine batch rendering already preserves successful outputs when another unit fails.
+
+## Timing authority
+
+Before TTS exists, estimates help design.
+
+After TTS exists, measured audio is authoritative.
+
+For v6 bridges, the engine can carry an event through one to three actual rendered spoken segments using `carry_through_segments`, avoiding guessed speech durations.
+
+Do not use MP3 tags as timing authority.
+
+## Reproducibility
+
+For durable production, record:
+
+- exact Audio Engine commit/SHA;
+- Program schema version;
+- exact Program JSON;
+- voice catalog/config used;
+- sound catalog and materialized asset hashes;
+- final manifest;
+- render report for batches.
+
+Reusable workflow consumers should pin `render.yml` and `engine_ref` to the same tested SHA.
+
+## Product-specific directors
+
+Audioguide and Audiobook directors may make different high-level decisions, but both compile to the same Audio Engine Program boundary.
+
+Audioguide-specific concerns such as physical location, station duration, navigation and interrupted listening remain consumer metadata.
+
+Audiobook-specific concerns such as book/chapter hierarchy, long-form continuity and chapter assembly remain consumer metadata.
+
+Neither concern belongs in the renderer unless a future reusable audio-rendering need is demonstrated independently of one product.
+
+## Unsupported requests
+
+A director/compiler must not silently translate unsupported wishes into misleading Program fields.
+
+Current explicit non-goals include:
+
+- overlapping-dialogue authoring;
+- random event scheduling;
+- arbitrary multitrack/DAW automation;
+- HRTF/binaural or front/rear/height positioning;
+- arbitrary public reverb/plugin parameters;
+- automatic music time-stretch;
+- automatic event looping without catalog permission;
+- authentic acoustics claims for named places;
+- network asset resolution during rendering.
+
+If a requested artistic instruction cannot be represented by the installed catalog and Program schema, report it as unsupported before expensive rendering.

--- a/docs/PRODUCTION_RECIPES.md
+++ b/docs/PRODUCTION_RECIPES.md
@@ -1,0 +1,314 @@
+# Production recipes
+
+These recipes are director-facing combinations of **capabilities already implemented by Audio Engine**. They do not add a second runtime contract.
+
+The machine-readable source of truth remains:
+
+```bash
+audio-engine capabilities
+audio-engine voices
+audio-engine sounds
+```
+
+If a recipe and the installed capability catalog ever disagree, the installed catalog wins.
+
+## Recipe 1 — Clean narration
+
+**Intent:** spoken narration with no environment.
+
+**Minimum schema:** v1.
+
+```json
+{
+  "schema_version": 1,
+  "id": "clean-narration",
+  "title": "Clean narration",
+  "segments": [
+    {
+      "preset": "narrateur-vif",
+      "text": "Le récit commence ici.",
+      "pause_after_ms": 450
+    }
+  ]
+}
+```
+
+Use this as the default. Do not add stereo or sound design when it does not improve the listening experience.
+
+## Recipe 2 — Stable dialogue placement
+
+**Intent:** make speakers easier to distinguish without theatrical hard panning.
+
+**Minimum schema:** v2.
+
+```json
+{
+  "schema_version": 2,
+  "id": "stable-dialogue",
+  "title": "Stable dialogue",
+  "actors": {
+    "narrator": {"placement": "center"},
+    "speaker-a": {"placement": "left"},
+    "speaker-b": {"placement": "right"}
+  },
+  "segments": [
+    {"character_id": "narrator", "preset": "narrateur-vif", "text": "Ils se font face."},
+    {"character_id": "speaker-a", "preset": "conteuse-chaleureuse", "text": "Je reste ici."},
+    {"character_id": "speaker-b", "preset": "officier-autorite", "text": "Et moi de l'autre côté."}
+  ]
+}
+```
+
+Keep a character's placement stable unless the story gives a real reason to move it.
+
+## Recipe 3 — Continuous environment under narration
+
+**Intent:** provide subtle context while speech stays dominant.
+
+**Minimum schema:** v3.
+
+```json
+{
+  "schema_version": 3,
+  "id": "texture-under-speech",
+  "title": "Texture under speech",
+  "soundscape": {
+    "bed": {
+      "sound": "cathedral-calm",
+      "gain_db": -23
+    },
+    "ducking": "speech"
+  },
+  "segments": [
+    {"preset": "narrateur-vif", "text": "La nef paraît immense."}
+  ]
+}
+```
+
+Capability mapping:
+
+- bed/layer narrative role: `texture`;
+- at most one bed;
+- at most two continuous layers;
+- global ducking: `speech` or `off`.
+
+Prefer `speech` when the environment competes with intelligibility.
+
+## Recipe 4 — Punctuation event
+
+**Intent:** underline one idea without giving the sound its own narrative space.
+
+**Minimum schema:** v3.
+
+```json
+{
+  "schema_version": 3,
+  "id": "punctuation",
+  "title": "Punctuation",
+  "soundscape": {
+    "events": [
+      {
+        "sound": "church-bell-distant",
+        "at_ms": 4200,
+        "gain_db": -18,
+        "placement": "right"
+      }
+    ],
+    "ducking": "speech"
+  },
+  "segments": [
+    {"preset": "narrateur-vif", "text": "Puis la cloche retentit."}
+  ]
+}
+```
+
+Use explicit `at_ms`. The public placement vocabulary is only `left`, `center`, `right`.
+
+## Recipe 5 — Let the sound take the scene
+
+**Intent:** narration stops and an event briefly carries information or emotion by itself.
+
+**Minimum schema:** v4.
+
+```json
+{
+  "schema_version": 4,
+  "id": "foreground-scene",
+  "title": "Foreground scene",
+  "soundscape": {
+    "events": [
+      {
+        "sound": "historic-horse-hooves",
+        "role": "scene",
+        "after_segment": 1,
+        "space_ms": 3200
+      }
+    ]
+  },
+  "segments": [
+    {"preset": "narrateur-vif", "text": "Quelque chose approche."},
+    {"preset": "narrateur-vif", "text": "Puis le récit reprend."}
+  ]
+}
+```
+
+`space_ms` is the entire narration-free window. Valid range is published in `capabilities.limits.scene_space_ms`.
+
+Use `scene` when the sound should finish before narration resumes.
+
+## Recipe 6 — Short acoustic accent
+
+**Intent:** give one short phrase a restrained spatial character without affecting the full narration.
+
+**Minimum schema:** v4.
+
+Author the meaningful phrase as its own segment:
+
+```json
+{
+  "schema_version": 4,
+  "id": "acoustic-accent",
+  "title": "Acoustic accent",
+  "segments": [
+    {"preset": "narrateur-vif", "text": "Il pousse la porte."},
+    {
+      "preset": "narrateur-vif",
+      "acoustic_space": "large-stone-interior",
+      "text": "Écoutez."
+    },
+    {"preset": "narrateur-vif", "text": "Le silence revient."}
+  ]
+}
+```
+
+The capability catalog recommends at most roughly 2500 ms rendered duration for an accent. If the phrase is too long, split it semantically; do not request arbitrary millisecond reverb automation.
+
+## Recipe 7 — Foreground event, then fixed carry under speech
+
+**Intent:** a sound arrives alone, then continues for a known absolute time after speech resumes.
+
+**Minimum schema:** v5.
+
+```json
+{
+  "schema_version": 5,
+  "id": "fixed-bridge",
+  "title": "Fixed bridge",
+  "soundscape": {
+    "events": [
+      {
+        "sound": "historic-horse-hooves",
+        "role": "bridge",
+        "after_segment": 1,
+        "foreground_ms": 3500,
+        "carry_under_speech_ms": 2500,
+        "gain_db": -23,
+        "placement": "left"
+      }
+    ],
+    "ducking": "speech"
+  },
+  "segments": [
+    {"preset": "narrateur-vif", "text": "Les cavaliers approchent."},
+    {"preset": "narrateur-vif", "text": "La voix reprend pendant qu'ils s'éloignent."}
+  ]
+}
+```
+
+Use fixed carry only when the millisecond overlap is itself the artistic intent.
+
+## Recipe 8 — Foreground event, then measured carry through speech
+
+**Intent:** let an event continue through the actual duration of following narration instead of guessing how long the voice will take.
+
+**Minimum schema:** v6.
+
+```json
+{
+  "schema_version": 6,
+  "id": "measured-bridge",
+  "title": "Measured bridge",
+  "soundscape": {
+    "events": [
+      {
+        "sound": "historic-pipe-organ",
+        "role": "bridge",
+        "after_segment": 1,
+        "foreground_ms": 5200,
+        "carry_through_segments": 1,
+        "tail_ms": 900,
+        "gain_db": -24
+      }
+    ],
+    "ducking": "speech"
+  },
+  "segments": [
+    {"preset": "narrateur-vif", "text": "L'orgue prend toute la place."},
+    {"preset": "narrateur-vif", "text": "Puis il reste sous la narration jusqu'à la fin de cette phrase."}
+  ]
+}
+```
+
+This is the preferred recipe when the desired instruction is “continue under the next sentence”.
+
+The measured speech timeline is the authority. `carry_through_segments` supports one to three following segments; optional `tail_ms` is bounded by the capability catalog.
+
+## Recipe 9 — Texture plus one narrative event
+
+**Intent:** retain environmental continuity while one event temporarily becomes important.
+
+**Minimum schema:** depends on event role:
+
+- punctuation: v3;
+- scene: v4;
+- bridge fixed carry: v5;
+- bridge measured carry: v6.
+
+Keep the environment bounded: one bed, at most two continuous layers and at most sixteen events. The mixer combines the deterministic environment track with speech and applies global speech ducking when requested.
+
+## Transition defaults
+
+Directors normally express semantics rather than hand-tuning every fade.
+
+Installed defaults are published under `capabilities.effects.transitions`:
+
+- continuous texture: fade in/out defaults;
+- punctuation: short exit fade;
+- scene: safe fade plus engine-owned pre/post margins;
+- bridge: longer fade-out, pre-roll and speech ducking behavior;
+- hard cut: supported only by explicit zero fade.
+
+Consult the installed catalog rather than copying numeric defaults into a consumer permanently.
+
+## Sound resources
+
+Recipes reference validated catalog ids for clarity. A production director should discover real ids with:
+
+```bash
+audio-engine sounds
+audio-engine sounds --type ambience
+audio-engine sounds --type event
+```
+
+A workspace-bounded local file may also be used where the Program contract permits it.
+
+Rendering never resolves arbitrary Web URLs.
+
+## What is not a recipe today
+
+Do not invent a recipe for a capability the engine does not expose.
+
+Not currently supported as first-class production semantics:
+
+- a separate `music` resource type;
+- automatic music time-stretch;
+- automatic looping of arbitrary event material;
+- overlapping dialogue;
+- random recurrence;
+- arbitrary multitrack automation;
+- numeric public panning;
+- HRTF/binaural positioning;
+- arbitrary reverb/plugin chains;
+- authentic acoustic simulation of a named place.
+
+A consumer may have a richer internal Production Plan, but it must either compile an intention to supported Program fields or report it as unsupported before rendering.

--- a/docs/PRODUCTION_RECIPES.md
+++ b/docs/PRODUCTION_RECIPES.md
@@ -12,6 +12,8 @@ audio-engine sounds
 
 If a recipe and the installed capability catalog ever disagree, the installed catalog wins.
 
+At the PROD-WP-001 baseline, the built-in reusable sound catalog contains no promoted entries (`entries: []`). Sound-directed examples below therefore use consumer-owned, workspace-bounded local files. A director must provision and lock those files before rendering, or promote validated reusable assets through the existing sound-acquisition governance.
+
 ## Recipe 1 — Clean narration
 
 **Intent:** spoken narration with no environment.
@@ -74,7 +76,7 @@ Keep a character's placement stable unless the story gives a real reason to move
   "title": "Texture under speech",
   "soundscape": {
     "bed": {
-      "sound": "cathedral-calm",
+      "file": "assets/cathedral-room-tone.wav",
       "gain_db": -23
     },
     "ducking": "speech"
@@ -108,7 +110,7 @@ Prefer `speech` when the environment competes with intelligibility.
   "soundscape": {
     "events": [
       {
-        "sound": "church-bell-distant",
+        "file": "assets/church-bell.wav",
         "at_ms": 4200,
         "gain_db": -18,
         "placement": "right"
@@ -138,7 +140,7 @@ Use explicit `at_ms`. The public placement vocabulary is only `left`, `center`, 
   "soundscape": {
     "events": [
       {
-        "sound": "historic-horse-hooves",
+        "file": "assets/horse-hooves.wav",
         "role": "scene",
         "after_segment": 1,
         "space_ms": 3200
@@ -197,7 +199,7 @@ The capability catalog recommends at most roughly 2500 ms rendered duration for 
   "soundscape": {
     "events": [
       {
-        "sound": "historic-horse-hooves",
+        "file": "assets/horse-hooves.wav",
         "role": "bridge",
         "after_segment": 1,
         "foreground_ms": 3500,
@@ -231,7 +233,7 @@ Use fixed carry only when the millisecond overlap is itself the artistic intent.
   "soundscape": {
     "events": [
       {
-        "sound": "historic-pipe-organ",
+        "file": "assets/pipe-organ.wav",
         "role": "bridge",
         "after_segment": 1,
         "foreground_ms": 5200,
@@ -282,7 +284,7 @@ Consult the installed catalog rather than copying numeric defaults into a consum
 
 ## Sound resources
 
-Recipes reference validated catalog ids for clarity. A production director should discover real ids with:
+Prefer validated catalog ids when the installed catalog contains suitable entries. Discover them with:
 
 ```bash
 audio-engine sounds
@@ -290,7 +292,7 @@ audio-engine sounds --type ambience
 audio-engine sounds --type event
 ```
 
-A workspace-bounded local file may also be used where the Program contract permits it.
+At the current baseline the built-in catalog is empty, so these recipes deliberately show workspace-bounded local files. Those paths are examples only: the consumer must supply the exact locked assets and their provenance/licence evidence before production.
 
 Rendering never resolves arbitrary Web URLs.
 


### PR DESCRIPTION
Implements phase A of #179.

What changes:
- defines the boundary between consumer-owned high-level Production Plans and Audio Engine Program v1..v6;
- documents the director discovery flow through existing capabilities / voices / sounds;
- publishes supported recipes mapped only to implemented semantics;
- explicitly documents unsupported requests;
- records that the built-in reusable sound catalog is currently empty, so sound-directed examples use consumer-owned locked local files;
- links the director interface from README.

What does not change:
- no new runtime schema;
- no new capability catalog;
- no TTS/provider change;
- no Voice Lab change;
- no product-specific Audioguide/Audiobook behavior in Audio Engine.

Gate targeted: DIRECTOR_INTERFACE_DOCUMENTED.