### PR TITLE
feat: add cheap offline Production preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Do not add:
 - Schema v6: measured relative bridge carry based on actual rendered spoken-segment duration; fixed v5 carry remains available.
 - Assembly remains schema v1.
 
-Core commands include `capabilities`, `voices`, `recommend`, `sounds`, `ambiences`, `ambience discover/qualify`, `render`, `batch`, `assemble`, and `validate`.
+Core commands include `capabilities`, `voices`, `recommend`, `sounds`, `ambiences`, `ambience discover/qualify`, `preflight`, `render`, `batch`, `assemble`, and `validate`.
 
 ## Production / Lab isolation
 
@@ -127,6 +127,16 @@ The `sound` module should produce **one deterministic environment WAV**. The mix
 - Production assets require provenance, licence and content hash.
 - Raw redistribution depends on the exact asset licence; commercial royalty-free files must not be republished standalone when forbidden.
 - Do not create a separate asset service without evidence.
+
+## Preflight governance
+
+`audio-engine preflight` is the cheap local Production gate between authoring and synthesis.
+
+- It must remain offline: no provider discovery, TTS, Web access or rendering.
+- Reuse the same contract, voice-resolution and asset-resolution rules as Production rendering.
+- Resolve validated preset ids and static local/materialized sound inputs before expensive work.
+- Do not claim that an explicit provider voice name is live-available unless a separate network check actually occurred.
+- Do not turn subjective artistic preferences into preflight failures.
 
 ## Engineering rules
 

--- a/docs/PRODUCTION_DIRECTORS.md
+++ b/docs/PRODUCTION_DIRECTORS.md
@@ -94,10 +94,13 @@ Before expensive synthesis, use deterministic checks first:
 
 ```bash
 audio-engine validate PROGRAM.json
+audio-engine preflight PROGRAM.json
 audio-engine timing PROGRAM.json --out output
 ```
 
-`validate` rejects invalid contract combinations.
+`validate` checks only the declared JSON contract. `preflight` then resolves the selected profile, validated local voice presets, local ambience/soundscape files and materialized sound-catalog references without provider discovery, TTS, Web access or rendering.
+
+Explicit provider voice names remain legal, but preflight deliberately does not query the remote provider to prove that a live voice name still exists; its report states `provider_voice_availability: not-network-checked`.
 
 `timing` gives measured cached durations when available and calibrated estimates otherwise. Estimates are design guidance, not final timing authority.
 
@@ -132,7 +135,9 @@ capability discovery
         |
 director compile
         |
-validate -------- FAIL -> stop cheaply
+validate
+        |
+preflight ------- FAIL -> stop cheaply
         |
 timing / risk selection
         |

--- a/src/audio_engine/cli.py
+++ b/src/audio_engine/cli.py
@@ -10,6 +10,7 @@ from .assemble import assemble_plan
 from .batch import render_batch
 from .contract import ContractError, load_json, validate_assembly, validate_program
 from .effects import load_capabilities, public_capabilities
+from .preflight import preflight_program
 from .preview import preview_program
 from .render import render_program
 from .sound.acquisition import DEFAULT_PROVIDERS, ensure_sound
@@ -103,6 +104,14 @@ def build_parser():
     assemble = sub.add_parser("assemble", help="Assemble existing audio assets")
     assemble.add_argument("plan")
     assemble.add_argument("--out", default="output")
+
+    preflight = sub.add_parser(
+        "preflight",
+        help="Resolve cheap local Production prerequisites without TTS or network access",
+    )
+    preflight.add_argument("program")
+    preflight.add_argument("--voices", default=None)
+    preflight.add_argument("--sounds", default=None)
 
     validate = sub.add_parser("validate", help="Validate a JSON contract")
     validate.add_argument("file")
@@ -214,6 +223,12 @@ def main(argv=None):
             )
         elif args.command == "timing":
             result = timing_report(args.program, args.out, voices_path=args.voices)
+        elif args.command == "preflight":
+            result = preflight_program(
+                args.program,
+                voices_path=args.voices,
+                sounds_path=args.sounds,
+            )
         elif args.command == "batch":
             result = render_batch(args.pattern, args.out, voices_path=args.voices, sounds_path=args.sounds)
         elif args.command == "assemble":

--- a/src/audio_engine/preflight.py
+++ b/src/audio_engine/preflight.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from .ambience.prepare import ambience_source_sha256
+from .contract import load_json, validate_program
+from .profiles import get_profile
+from .sound.render import soundscape_source_sha256
+from .voices import load_voice_config, resolve_segments
+
+
+def preflight_program(program_path, voices_path=None, sounds_path=None):
+    """Resolve every cheap, local prerequisite without synthesizing audio.
+
+    This deliberately performs no provider discovery, TTS, Web access or
+    rendering. Explicit provider voice names are therefore not checked against
+    the provider's live catalog; validated preset ids are resolved locally.
+    """
+    program_path = Path(program_path)
+    program = validate_program(load_json(program_path))
+
+    profile_name = program.get("profile", "speech")
+    get_profile(profile_name)
+
+    voice_config, _ = load_voice_config(voices_path)
+    resolved = resolve_segments(program, voice_config)
+
+    ambience_sha256 = None
+    soundscape_sha256 = None
+    if program.get("ambience"):
+        ambience_sha256 = ambience_source_sha256(program["ambience"], program_path)
+    if program.get("soundscape"):
+        soundscape_sha256 = soundscape_source_sha256(
+            program["soundscape"],
+            program_path,
+            sounds_path,
+        )
+
+    preset_segments = sum(1 for segment in program["segments"] if segment.get("preset"))
+    explicit_voice_segments = sum(1 for segment in program["segments"] if segment.get("voice"))
+
+    return {
+        "status": "ready",
+        "program_id": program["id"],
+        "schema_version": program["schema_version"],
+        "profile": profile_name,
+        "segment_count": len(resolved),
+        "resolved_voice_count": len({segment["voice"] for segment in resolved}),
+        "preset_segments": preset_segments,
+        "explicit_provider_voice_segments": explicit_voice_segments,
+        "provider_voice_availability": "not-network-checked",
+        "ambience_resolved": ambience_sha256 is not None,
+        "soundscape_resolved": soundscape_sha256 is not None,
+        "static_inputs_resolved": True,
+        "network_access": False,
+        "tts_calls": 0,
+    }

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,109 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from audio_engine.preflight import preflight_program
+
+
+class PreflightTests(unittest.TestCase):
+    def _write_program(self, root, data, name="program.json"):
+        path = Path(root) / name
+        path.write_text(json.dumps(data), encoding="utf-8")
+        return path
+
+    def test_resolves_validated_preset_without_tts(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            program = self._write_program(temp_value, {
+                "schema_version": 1,
+                "id": "preflight-ok",
+                "title": "Preflight OK",
+                "segments": [
+                    {"preset": "narrateur-vif", "text": "Bonjour."}
+                ],
+            })
+            result = preflight_program(program)
+            self.assertEqual(result["status"], "ready")
+            self.assertEqual(result["segment_count"], 1)
+            self.assertEqual(result["preset_segments"], 1)
+            self.assertEqual(result["tts_calls"], 0)
+            self.assertFalse(result["network_access"])
+
+    def test_rejects_unknown_preset_before_tts(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            program = self._write_program(temp_value, {
+                "schema_version": 1,
+                "id": "preflight-bad-preset",
+                "title": "Bad preset",
+                "segments": [
+                    {"preset": "does-not-exist", "text": "Bonjour."}
+                ],
+            })
+            with self.assertRaisesRegex(ValueError, "Unknown voice preset"):
+                preflight_program(program)
+
+    def test_rejects_missing_sound_file_before_tts(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            program = self._write_program(temp_value, {
+                "schema_version": 3,
+                "id": "preflight-missing-sound",
+                "title": "Missing sound",
+                "soundscape": {
+                    "events": [
+                        {"file": "assets/missing.wav", "at_ms": 0}
+                    ]
+                },
+                "segments": [
+                    {"preset": "narrateur-vif", "text": "Bonjour."}
+                ],
+            })
+            with self.assertRaises(FileNotFoundError):
+                preflight_program(program)
+
+    def test_resolves_local_sound_without_rendering_it(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            root = Path(temp_value)
+            assets = root / "assets"
+            assets.mkdir()
+            # Preflight checks exact local input resolution/hash only; decode/render
+            # remains a later stage.
+            (assets / "event.wav").write_bytes(b"locked-reference-bytes")
+            program = self._write_program(root, {
+                "schema_version": 3,
+                "id": "preflight-local-sound",
+                "title": "Local sound",
+                "soundscape": {
+                    "events": [
+                        {"file": "assets/event.wav", "at_ms": 0}
+                    ]
+                },
+                "segments": [
+                    {"preset": "narrateur-vif", "text": "Bonjour."}
+                ],
+            })
+            result = preflight_program(program)
+            self.assertTrue(result["soundscape_resolved"])
+            self.assertTrue(result["static_inputs_resolved"])
+            self.assertEqual(result["tts_calls"], 0)
+
+    def test_explicit_provider_voice_is_not_live_network_checked(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            program = self._write_program(temp_value, {
+                "schema_version": 1,
+                "id": "preflight-explicit-voice",
+                "title": "Explicit voice",
+                "segments": [
+                    {"voice": "fr-FR-SomeProviderVoice", "text": "Bonjour."}
+                ],
+            })
+            result = preflight_program(program)
+            self.assertEqual(result["explicit_provider_voice_segments"], 1)
+            self.assertEqual(
+                result["provider_voice_availability"],
+                "not-network-checked",
+            )
+            self.assertFalse(result["network_access"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements phase B of #179.

Adds a deliberately thin `audio-engine preflight` command that reuses Production contract/voice/asset resolution without contacting Edge, the Web, or rendering audio.

It catches before TTS:
- invalid Program contract;
- unknown local validated preset;
- invalid profile;
- missing/escaping local ambience/sound assets;
- unknown/unmaterialized/mismatched sound catalog assets;
- character voice-resolution conflicts already enforced by Production.

It deliberately does **not** live-query explicit provider voice names; the machine result states `provider_voice_availability: not-network-checked`.

Also:
- documents preflight in the Production Director flow;
- governs it in AGENTS.md so artistic preferences cannot become hard preflight failures;
- adds offline regression tests.

No provider/model/Lab/product-specific change.

Target gate: CHEAP_PREFLIGHT_PASS.