### PR TITLE
lab: add Azure expressive synthesis helper

### DIFF
--- a/src/audio_engine/voice_lab_azure.py
+++ b/src/audio_engine/voice_lab_azure.py
@@ -1,0 +1,205 @@
+"""Azure Speech expressive synthesis helper for Voice Casting Lab only.
+
+This module is intentionally not wired into Production rendering.
+"""
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import os
+import re
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+_REGION_RE = re.compile(r"^[a-z0-9-]+$")
+DEFAULT_OUTPUT_FORMAT = "audio-24khz-96kbitrate-mono-mp3"
+
+
+class AzureSpeechLabError(RuntimeError):
+    pass
+
+
+def _attr(value: str) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def build_ssml(
+    text: str,
+    voice: str,
+    *,
+    locale: str = "fr-FR",
+    style: str | None = None,
+    styledegree: float | None = None,
+    rate: str | None = None,
+    pitch: str | None = None,
+    volume: str | None = None,
+) -> str:
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("text is required")
+    if not isinstance(voice, str) or not voice.strip():
+        raise ValueError("voice is required")
+    if styledegree is not None:
+        if style is None:
+            raise ValueError("styledegree requires style")
+        styledegree = float(styledegree)
+        if not 0.01 <= styledegree <= 2.0:
+            raise ValueError("styledegree must be between 0.01 and 2.0")
+
+    body = html.escape(text)
+    prosody_attrs = []
+    if rate is not None:
+        prosody_attrs.append(f'rate="{_attr(rate)}"')
+    if pitch is not None:
+        prosody_attrs.append(f'pitch="{_attr(pitch)}"')
+    if volume is not None:
+        prosody_attrs.append(f'volume="{_attr(volume)}"')
+    if prosody_attrs:
+        body = f"<prosody {' '.join(prosody_attrs)}>{body}</prosody>"
+
+    if style is not None:
+        attrs = [f'style="{_attr(style)}"']
+        if styledegree is not None:
+            attrs.append(f'styledegree="{styledegree:g}"')
+        body = f"<mstts:express-as {' '.join(attrs)}>{body}</mstts:express-as>"
+
+    return (
+        f'<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" '
+        f'xmlns:mstts="https://www.w3.org/2001/mstts" xml:lang="{_attr(locale)}">'
+        f'<voice name="{_attr(voice)}">{body}</voice></speak>'
+    )
+
+
+def request_manifest(
+    text: str,
+    voice: str,
+    region: str,
+    *,
+    locale: str = "fr-FR",
+    style: str | None = None,
+    styledegree: float | None = None,
+    rate: str | None = None,
+    pitch: str | None = None,
+    volume: str | None = None,
+    output_format: str = DEFAULT_OUTPUT_FORMAT,
+) -> dict:
+    ssml = build_ssml(
+        text,
+        voice,
+        locale=locale,
+        style=style,
+        styledegree=styledegree,
+        rate=rate,
+        pitch=pitch,
+        volume=volume,
+    )
+    return {
+        "provider": "azure-speech-lab",
+        "processing": "remote",
+        "region": region,
+        "voice": voice,
+        "locale": locale,
+        "style": style,
+        "styledegree": styledegree,
+        "rate": rate,
+        "pitch": pitch,
+        "volume": volume,
+        "output_format": output_format,
+        "text_chars": len(text),
+        "text_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "ssml_sha256": hashlib.sha256(ssml.encode("utf-8")).hexdigest(),
+    }
+
+
+class AzureSpeechLabClient:
+    def __init__(self, key: str, region: str, *, opener=urlopen):
+        if not key:
+            raise AzureSpeechLabError("AZURE_SPEECH_KEY is required")
+        if not region:
+            raise AzureSpeechLabError("AZURE_SPEECH_REGION is required")
+        region = region.strip().lower()
+        if not _REGION_RE.fullmatch(region):
+            raise AzureSpeechLabError("AZURE_SPEECH_REGION is invalid")
+        self._key = key
+        self.region = region
+        self._opener = opener
+
+    @classmethod
+    def from_env(cls, *, opener=urlopen):
+        return cls(
+            os.environ.get("AZURE_SPEECH_KEY", ""),
+            os.environ.get("AZURE_SPEECH_REGION", ""),
+            opener=opener,
+        )
+
+    @property
+    def endpoint(self) -> str:
+        return f"https://{self.region}.tts.speech.microsoft.com/cognitiveservices/v1"
+
+    def synthesize(
+        self,
+        text: str,
+        voice: str,
+        path,
+        *,
+        locale: str = "fr-FR",
+        style: str | None = None,
+        styledegree: float | None = None,
+        rate: str | None = None,
+        pitch: str | None = None,
+        volume: str | None = None,
+        output_format: str = DEFAULT_OUTPUT_FORMAT,
+    ) -> dict:
+        ssml = build_ssml(
+            text,
+            voice,
+            locale=locale,
+            style=style,
+            styledegree=styledegree,
+            rate=rate,
+            pitch=pitch,
+            volume=volume,
+        )
+        request = Request(
+            self.endpoint,
+            data=ssml.encode("utf-8"),
+            method="POST",
+            headers={
+                "Ocp-Apim-Subscription-Key": self._key,
+                "Content-Type": "application/ssml+xml",
+                "X-Microsoft-OutputFormat": output_format,
+                "User-Agent": "recit-audio-engine-voice-lab",
+            },
+        )
+        try:
+            with self._opener(request, timeout=90) as response:
+                payload = response.read()
+        except Exception as exc:
+            raise AzureSpeechLabError(f"Azure Speech synthesis failed: {exc}") from exc
+        if not payload:
+            raise AzureSpeechLabError("Azure Speech returned empty audio")
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+        manifest = request_manifest(
+            text,
+            voice,
+            self.region,
+            locale=locale,
+            style=style,
+            styledegree=styledegree,
+            rate=rate,
+            pitch=pitch,
+            volume=volume,
+            output_format=output_format,
+        )
+        manifest["audio_bytes"] = len(payload)
+        manifest["audio_sha256"] = hashlib.sha256(payload).hexdigest()
+        return manifest
+
+
+def write_manifest(path, manifest: dict) -> None:
+    Path(path).write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/test_voice_lab_azure.py
+++ b/tests/test_voice_lab_azure.py
@@ -1,0 +1,85 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from audio_engine.voice_lab_azure import (
+    AzureSpeechLabClient,
+    AzureSpeechLabError,
+    build_ssml,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload=b"fake-mp3"):
+        self.payload = payload
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        return False
+    def read(self):
+        return self.payload
+
+
+class AzureSpeechLabTests(unittest.TestCase):
+    def test_ssml_escapes_text_and_serializes_style(self):
+        ssml = build_ssml(
+            'Ulysse & Pénélope < ensemble',
+            'fr-FR-HenriNeural',
+            style='sad',
+            styledegree=0.75,
+            rate='-4%',
+            pitch='-10Hz',
+            volume='+2%',
+        )
+        self.assertIn('Ulysse &amp; Pénélope &lt; ensemble', ssml)
+        self.assertIn('mstts:express-as style="sad" styledegree="0.75"', ssml)
+        self.assertIn('prosody rate="-4%" pitch="-10Hz" volume="+2%"', ssml)
+        self.assertIn('voice name="fr-FR-HenriNeural"', ssml)
+
+    def test_invalid_styledegree_rejected(self):
+        with self.assertRaises(ValueError):
+            build_ssml("Bonjour", "fr-FR-HenriNeural", style="sad", styledegree=2.1)
+        with self.assertRaises(ValueError):
+            build_ssml("Bonjour", "fr-FR-HenriNeural", styledegree=1.0)
+
+    def test_missing_credentials_fail_explicitly(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(AzureSpeechLabError):
+                AzureSpeechLabClient.from_env()
+
+    def test_request_uses_region_headers_and_writes_audio(self):
+        captured = {}
+        def opener(request, timeout):
+            captured["url"] = request.full_url
+            captured["headers"] = dict(request.header_items())
+            captured["body"] = request.data.decode("utf-8")
+            captured["timeout"] = timeout
+            return FakeResponse(b"abc123")
+
+        client = AzureSpeechLabClient("secret", "francecentral", opener=opener)
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "clip.mp3"
+            manifest = client.synthesize(
+                "Pénélope…",
+                "fr-FR-HenriNeural",
+                out,
+                style="sad",
+                styledegree=0.8,
+            )
+            self.assertEqual(out.read_bytes(), b"abc123")
+        self.assertEqual(
+            captured["url"],
+            "https://francecentral.tts.speech.microsoft.com/cognitiveservices/v1",
+        )
+        headers = {k.lower(): v for k, v in captured["headers"].items()}
+        self.assertEqual(headers["ocp-apim-subscription-key"], "secret")
+        self.assertEqual(headers["x-microsoft-outputformat"], "audio-24khz-96kbitrate-mono-mp3")
+        self.assertIn('style="sad"', captured["body"])
+        self.assertEqual(manifest["provider"], "azure-speech-lab")
+        self.assertNotIn("key", manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #192.

Adds a Voice Casting Lab-only Azure Speech helper:
- direct REST, no Azure SDK dependency;
- SSML with `mstts:express-as`;
- bounded `styledegree`;
- optional prosody rate/pitch/volume;
- deterministic manifest without secrets;
- explicit env credential failure;
- unit tests with mocked network only.

No Production provider wiring.
No default render change.
No Odyssée-specific logic.

Consumer after merge: stefm78/recit-audioguide#108.