### PR TITLE
prod: add immutable Production Manifest v1

### DIFF
--- a/docs/PRODUCTION_MANIFEST.md
+++ b/docs/PRODUCTION_MANIFEST.md
@@ -8,7 +8,7 @@ It is deliberately product-agnostic. A consumer may call its units scenes, chapt
 
 - `engine_ref` is an exact 40-character Git commit SHA.
 - Every unit declares a provider. There is no implicit provider fallback.
-- A `ready` unit pins a local Program and local voice pack by SHA-256.
+- A `ready` unit pins a workspace-relative Program and voice pack by SHA-256.
 - A `hold` unit carries an explicit reason and may remain incomplete without blocking unrelated units.
 - Every unit belongs to exactly one assembly.
 - The master includes every assembly exactly once.
@@ -50,8 +50,8 @@ Commands:
 
 ```bash
 audio-engine production validate path/to/production.json
-audio-engine production validate path/to/production.json --verify-files
-audio-engine production plan path/to/production.json
+audio-engine production validate path/to/production.json --verify-files --workspace-root .
+audio-engine production plan path/to/production.json --workspace-root .
 ```
 
 The plan output is designed to feed the same shard executor contract on GitHub-hosted runners or a future persistent worker. Executor selection is operational policy, not manifest semantics.

--- a/docs/PRODUCTION_MANIFEST.md
+++ b/docs/PRODUCTION_MANIFEST.md
@@ -1,0 +1,57 @@
+# Production Manifest v1
+
+Production Manifest v1 is the executor-neutral boundary between a consumer repository and Audio Engine.
+
+It is deliberately product-agnostic. A consumer may call its units scenes, chapters, lessons, or anything else; the engine sees only independently renderable `units`, ordered `assemblies`, and one ordered `master`.
+
+## Invariants
+
+- `engine_ref` is an exact 40-character Git commit SHA.
+- Every unit declares a provider. There is no implicit provider fallback.
+- A `ready` unit pins a local Program and local voice pack by SHA-256.
+- A `hold` unit carries an explicit reason and may remain incomplete without blocking unrelated units.
+- Every unit belongs to exactly one assembly.
+- The master includes every assembly exactly once.
+- `production plan` is offline and verifies hashes before expensive rendering.
+- Cache state is not part of the manifest and never changes correctness.
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "id": "story-v1",
+  "engine_ref": "1111111111111111111111111111111111111111",
+  "units": [
+    {
+      "id": "scene-01",
+      "state": "ready",
+      "provider": "edge",
+      "program": "programs/scene-01.json",
+      "program_sha256": "<sha256>",
+      "voice_pack": "voices/production.json",
+      "voice_pack_sha256": "<sha256>"
+    },
+    {
+      "id": "scene-02",
+      "state": "hold",
+      "provider": "local-expressive-v1",
+      "hold_reason": "voice package not promoted"
+    }
+  ],
+  "assemblies": [
+    {"id": "block-a", "units": ["scene-01", "scene-02"]}
+  ],
+  "master": {"assemblies": ["block-a"]}
+}
+```
+
+Commands:
+
+```bash
+audio-engine production validate path/to/production.json
+audio-engine production validate path/to/production.json --verify-files
+audio-engine production plan path/to/production.json
+```
+
+The plan output is designed to feed the same shard executor contract on GitHub-hosted runners or a future persistent worker. Executor selection is operational policy, not manifest semantics.

--- a/src/audio_engine/cli.py
+++ b/src/audio_engine/cli.py
@@ -12,6 +12,7 @@ from .contract import ContractError, load_json, validate_assembly, validate_prog
 from .effects import load_capabilities, public_capabilities
 from .preflight import preflight_program
 from .preview import preview_program
+from .production import production_plan, validate_production_manifest
 from .render import render_program
 from .sound.acquisition import DEFAULT_PROVIDERS, ensure_sound
 from .sound.catalog import SOUND_TYPES, public_catalog as public_sound_catalog, sound_info
@@ -112,6 +113,23 @@ def build_parser():
     preflight.add_argument("program")
     preflight.add_argument("--voices", default=None)
     preflight.add_argument("--sounds", default=None)
+
+    production = sub.add_parser(
+        "production",
+        help="Validate and plan an immutable Production Manifest v1",
+    )
+    production_sub = production.add_subparsers(dest="production_command", required=True)
+    production_validate = production_sub.add_parser(
+        "validate",
+        help="Validate a Production Manifest v1 without rendering",
+    )
+    production_validate.add_argument("manifest")
+    production_validate.add_argument("--verify-files", action="store_true")
+    production_plan_parser = production_sub.add_parser(
+        "plan",
+        help="Verify ready inputs and emit an executor-neutral shard/fan-in plan",
+    )
+    production_plan_parser.add_argument("manifest")
 
     validate = sub.add_parser("validate", help="Validate a JSON contract")
     validate.add_argument("file")
@@ -229,6 +247,16 @@ def main(argv=None):
                 voices_path=args.voices,
                 sounds_path=args.sounds,
             )
+        elif args.command == "production":
+            if args.production_command == "validate":
+                manifest = load_json(args.manifest)
+                result = validate_production_manifest(
+                    manifest,
+                    manifest_path=args.manifest,
+                    verify_files=args.verify_files,
+                )
+            else:
+                result = production_plan(args.manifest)
         elif args.command == "batch":
             result = render_batch(args.pattern, args.out, voices_path=args.voices, sounds_path=args.sounds)
         elif args.command == "assemble":

--- a/src/audio_engine/cli.py
+++ b/src/audio_engine/cli.py
@@ -125,11 +125,13 @@ def build_parser():
     )
     production_validate.add_argument("manifest")
     production_validate.add_argument("--verify-files", action="store_true")
+    production_validate.add_argument("--workspace-root", default=".")
     production_plan_parser = production_sub.add_parser(
         "plan",
         help="Verify ready inputs and emit an executor-neutral shard/fan-in plan",
     )
     production_plan_parser.add_argument("manifest")
+    production_plan_parser.add_argument("--workspace-root", default=".")
 
     validate = sub.add_parser("validate", help="Validate a JSON contract")
     validate.add_argument("file")
@@ -253,10 +255,11 @@ def main(argv=None):
                 result = validate_production_manifest(
                     manifest,
                     manifest_path=args.manifest,
+                    workspace_root=args.workspace_root,
                     verify_files=args.verify_files,
                 )
             else:
-                result = production_plan(args.manifest)
+                result = production_plan(args.manifest, workspace_root=args.workspace_root)
         elif args.command == "batch":
             result = render_batch(args.pattern, args.out, voices_path=args.voices, sounds_path=args.sounds)
         elif args.command == "assemble":

--- a/src/audio_engine/production.py
+++ b/src/audio_engine/production.py
@@ -1,0 +1,242 @@
+import hashlib
+import json
+import re
+from pathlib import Path
+
+from .contract import ContractError, load_json
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_UNIT_STATES = ("ready", "hold")
+
+
+def _non_empty(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _validate_relpath(value, label, errors):
+    if not _non_empty(value):
+        errors.append(f"{label} must be a non-empty relative path")
+        return
+    if "://" in value or Path(value).is_absolute():
+        errors.append(f"{label} must be a local relative path")
+        return
+    if ".." in Path(value).parts:
+        errors.append(f"{label} must not escape the manifest workspace")
+
+
+def _validate_sha256(value, label, errors):
+    if not isinstance(value, str) or not _SHA256_RE.fullmatch(value):
+        errors.append(f"{label} must be a lowercase SHA-256 hex digest")
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _resolve_local(manifest_path, relative):
+    base = Path(manifest_path).resolve().parent
+    target = (base / relative).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise ContractError(f"path escapes manifest workspace: {relative}") from exc
+    return target
+
+
+def validate_production_manifest(manifest, manifest_path=None, verify_files=False):
+    errors = []
+    if not isinstance(manifest, dict):
+        raise ContractError("production manifest must be an object")
+    if manifest.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    if not _non_empty(manifest.get("id")):
+        errors.append("id is required")
+    engine_ref = manifest.get("engine_ref")
+    if not isinstance(engine_ref, str) or not _GIT_SHA_RE.fullmatch(engine_ref):
+        errors.append("engine_ref must be an exact 40-character lowercase Git commit SHA")
+
+    units = manifest.get("units")
+    if not isinstance(units, list) or not units:
+        errors.append("units must be a non-empty array")
+        units = []
+
+    unit_ids = set()
+    normalized_units = []
+    for index, unit in enumerate(units, start=1):
+        label = f"units[{index}]"
+        if not isinstance(unit, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        unit_id = unit.get("id")
+        if not _non_empty(unit_id):
+            errors.append(f"{label}.id is required")
+            continue
+        if unit_id in unit_ids:
+            errors.append(f"duplicate unit id: {unit_id}")
+            continue
+        unit_ids.add(unit_id)
+        state = unit.get("state")
+        if state not in _UNIT_STATES:
+            errors.append(f"{label}.state must be one of {', '.join(_UNIT_STATES)}")
+        provider = unit.get("provider")
+        if not _non_empty(provider):
+            errors.append(f"{label}.provider is required; fallback is never implicit")
+
+        if state == "hold":
+            if not _non_empty(unit.get("hold_reason")):
+                errors.append(f"{label}.hold_reason is required when state=hold")
+        elif state == "ready":
+            for field in ("program", "voice_pack"):
+                _validate_relpath(unit.get(field), f"{label}.{field}", errors)
+            for field in ("program_sha256", "voice_pack_sha256"):
+                _validate_sha256(unit.get(field), f"{label}.{field}", errors)
+
+        normalized_units.append(unit)
+
+    assemblies = manifest.get("assemblies")
+    if not isinstance(assemblies, list) or not assemblies:
+        errors.append("assemblies must be a non-empty array")
+        assemblies = []
+
+    assembly_ids = set()
+    referenced_units = []
+    for index, assembly in enumerate(assemblies, start=1):
+        label = f"assemblies[{index}]"
+        if not isinstance(assembly, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        assembly_id = assembly.get("id")
+        if not _non_empty(assembly_id):
+            errors.append(f"{label}.id is required")
+            continue
+        if assembly_id in assembly_ids:
+            errors.append(f"duplicate assembly id: {assembly_id}")
+            continue
+        assembly_ids.add(assembly_id)
+        inputs = assembly.get("units")
+        if not isinstance(inputs, list) or not inputs or not all(_non_empty(v) for v in inputs):
+            errors.append(f"{label}.units must be a non-empty array of unit ids")
+            continue
+        if len(inputs) != len(set(inputs)):
+            errors.append(f"{label}.units contains duplicates")
+        unknown = sorted(set(inputs) - unit_ids)
+        if unknown:
+            errors.append(f"{label}.units references unknown units: {unknown}")
+        referenced_units.extend(inputs)
+
+    if unit_ids and set(referenced_units) != unit_ids:
+        missing = sorted(unit_ids - set(referenced_units))
+        extra = sorted(set(referenced_units) - unit_ids)
+        errors.append(f"assemblies must cover every unit exactly once; missing={missing}, extra={extra}")
+    duplicates = sorted({u for u in referenced_units if referenced_units.count(u) > 1})
+    if duplicates:
+        errors.append(f"units may belong to only one assembly: {duplicates}")
+
+    master = manifest.get("master")
+    if not isinstance(master, dict):
+        errors.append("master must be an object")
+    else:
+        inputs = master.get("assemblies")
+        if not isinstance(inputs, list) or not inputs or not all(_non_empty(v) for v in inputs):
+            errors.append("master.assemblies must be a non-empty ordered array")
+        else:
+            if len(inputs) != len(set(inputs)):
+                errors.append("master.assemblies contains duplicates")
+            unknown = sorted(set(inputs) - assembly_ids)
+            if unknown:
+                errors.append(f"master.assemblies references unknown assemblies: {unknown}")
+            if set(inputs) != assembly_ids:
+                missing = sorted(assembly_ids - set(inputs))
+                errors.append(f"master.assemblies must include every assembly; missing={missing}")
+
+    if verify_files and manifest_path:
+        for index, unit in enumerate(normalized_units, start=1):
+            if unit.get("state") != "ready":
+                continue
+            for field, hash_field in (("program", "program_sha256"), ("voice_pack", "voice_pack_sha256")):
+                relative = unit.get(field)
+                expected = unit.get(hash_field)
+                if not (_non_empty(relative) and isinstance(expected, str) and _SHA256_RE.fullmatch(expected)):
+                    continue
+                try:
+                    path = _resolve_local(manifest_path, relative)
+                except ContractError as exc:
+                    errors.append(f"units[{index}].{field}: {exc}")
+                    continue
+                if not path.is_file():
+                    errors.append(f"units[{index}].{field} not found: {relative}")
+                    continue
+                actual = _sha256(path)
+                if actual != expected:
+                    errors.append(
+                        f"units[{index}].{hash_field} mismatch for {relative}: expected {expected}, got {actual}"
+                    )
+
+    if errors:
+        raise ContractError("; ".join(errors))
+    return manifest
+
+
+def production_plan(manifest_path, verify_files=True):
+    manifest_path = Path(manifest_path)
+    manifest = validate_production_manifest(
+        load_json(manifest_path),
+        manifest_path=manifest_path,
+        verify_files=verify_files,
+    )
+    unit_to_assembly = {}
+    for assembly in manifest["assemblies"]:
+        for unit_id in assembly["units"]:
+            unit_to_assembly[unit_id] = assembly["id"]
+
+    ready_units = []
+    held_units = []
+    by_id = {unit["id"]: unit for unit in manifest["units"]}
+    for unit in manifest["units"]:
+        item = {
+            "id": unit["id"],
+            "assembly": unit_to_assembly[unit["id"]],
+            "provider": unit["provider"],
+        }
+        if unit["state"] == "ready":
+            item.update(
+                program=unit["program"],
+                program_sha256=unit["program_sha256"],
+                voice_pack=unit["voice_pack"],
+                voice_pack_sha256=unit["voice_pack_sha256"],
+            )
+            ready_units.append(item)
+        else:
+            item["hold_reason"] = unit["hold_reason"]
+            held_units.append(item)
+
+    assembly_plan = []
+    for assembly in manifest["assemblies"]:
+        held = [uid for uid in assembly["units"] if by_id[uid]["state"] != "ready"]
+        assembly_plan.append({
+            "id": assembly["id"],
+            "units": assembly["units"],
+            "state": "ready" if not held else "hold",
+            "held_units": held,
+        })
+
+    held_assemblies = [a["id"] for a in assembly_plan if a["state"] != "ready"]
+    return {
+        "schema_version": 1,
+        "manifest_id": manifest["id"],
+        "manifest_sha256": _sha256(manifest_path),
+        "engine_ref": manifest["engine_ref"],
+        "ready_units": ready_units,
+        "held_units": held_units,
+        "assemblies": assembly_plan,
+        "master": {
+            "assemblies": manifest["master"]["assemblies"],
+            "state": "ready" if not held_assemblies else "hold",
+            "held_assemblies": held_assemblies,
+        },
+    }

--- a/src/audio_engine/production.py
+++ b/src/audio_engine/production.py
@@ -38,17 +38,17 @@ def _sha256(path):
     return digest.hexdigest()
 
 
-def _resolve_local(manifest_path, relative):
-    base = Path(manifest_path).resolve().parent
+def _resolve_local(workspace_root, relative):
+    base = Path(workspace_root).resolve()
     target = (base / relative).resolve()
     try:
         target.relative_to(base)
     except ValueError as exc:
-        raise ContractError(f"path escapes manifest workspace: {relative}") from exc
+        raise ContractError(f"path escapes workspace root: {relative}") from exc
     return target
 
 
-def validate_production_manifest(manifest, manifest_path=None, verify_files=False):
+def validate_production_manifest(manifest, manifest_path=None, workspace_root=".", verify_files=False):
     errors = []
     if not isinstance(manifest, dict):
         raise ContractError("production manifest must be an object")
@@ -164,7 +164,7 @@ def validate_production_manifest(manifest, manifest_path=None, verify_files=Fals
                 if not (_non_empty(relative) and isinstance(expected, str) and _SHA256_RE.fullmatch(expected)):
                     continue
                 try:
-                    path = _resolve_local(manifest_path, relative)
+                    path = _resolve_local(workspace_root, relative)
                 except ContractError as exc:
                     errors.append(f"units[{index}].{field}: {exc}")
                     continue
@@ -182,11 +182,12 @@ def validate_production_manifest(manifest, manifest_path=None, verify_files=Fals
     return manifest
 
 
-def production_plan(manifest_path, verify_files=True):
+def production_plan(manifest_path, workspace_root=".", verify_files=True):
     manifest_path = Path(manifest_path)
     manifest = validate_production_manifest(
         load_json(manifest_path),
         manifest_path=manifest_path,
+        workspace_root=workspace_root,
         verify_files=verify_files,
     )
     unit_to_assembly = {}

--- a/tests/test_production_manifest.py
+++ b/tests/test_production_manifest.py
@@ -59,7 +59,7 @@ class ProductionManifestTests(unittest.TestCase):
             manifest["units"][0]["voice_pack_sha256"] = sha256(root / "voices.json")
             path = root / "production.json"
             path.write_text(json.dumps(manifest), encoding="utf-8")
-            plan = production_plan(path)
+            plan = production_plan(path, workspace_root=root)
             self.assertEqual([u["id"] for u in plan["ready_units"]], ["u1"])
             self.assertEqual([u["id"] for u in plan["held_units"]], ["u2"])
             self.assertEqual(plan["assemblies"][0]["state"], "hold")
@@ -74,7 +74,7 @@ class ProductionManifestTests(unittest.TestCase):
             path = root / "production.json"
             path.write_text(json.dumps(manifest), encoding="utf-8")
             with self.assertRaisesRegex(ContractError, "mismatch"):
-                production_plan(path)
+                production_plan(path, workspace_root=root)
 
 
 if __name__ == "__main__":

--- a/tests/test_production_manifest.py
+++ b/tests/test_production_manifest.py
@@ -1,0 +1,81 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from audio_engine.contract import ContractError
+from audio_engine.production import production_plan, validate_production_manifest
+
+
+def sha256(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+class ProductionManifestTests(unittest.TestCase):
+    def base_manifest(self):
+        return {
+            "schema_version": 1,
+            "id": "sample-production",
+            "engine_ref": "1" * 40,
+            "units": [
+                {
+                    "id": "u1",
+                    "state": "ready",
+                    "provider": "edge",
+                    "program": "u1.json",
+                    "program_sha256": "a" * 64,
+                    "voice_pack": "voices.json",
+                    "voice_pack_sha256": "b" * 64,
+                },
+                {
+                    "id": "u2",
+                    "state": "hold",
+                    "provider": "promoted-local",
+                    "hold_reason": "voice package not promoted",
+                },
+            ],
+            "assemblies": [{"id": "g1", "units": ["u1", "u2"]}],
+            "master": {"assemblies": ["g1"]},
+        }
+
+    def test_hold_unit_does_not_require_missing_files(self):
+        manifest = self.base_manifest()
+        self.assertIs(validate_production_manifest(manifest), manifest)
+
+    def test_provider_is_mandatory_no_implicit_fallback(self):
+        manifest = self.base_manifest()
+        del manifest["units"][0]["provider"]
+        with self.assertRaisesRegex(ContractError, "provider is required"):
+            validate_production_manifest(manifest)
+
+    def test_ready_hashes_are_verified(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "u1.json").write_text('{"id":"u1"}', encoding="utf-8")
+            (root / "voices.json").write_text('{"version":1}', encoding="utf-8")
+            manifest = self.base_manifest()
+            manifest["units"][0]["program_sha256"] = sha256(root / "u1.json")
+            manifest["units"][0]["voice_pack_sha256"] = sha256(root / "voices.json")
+            path = root / "production.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            plan = production_plan(path)
+            self.assertEqual([u["id"] for u in plan["ready_units"]], ["u1"])
+            self.assertEqual([u["id"] for u in plan["held_units"]], ["u2"])
+            self.assertEqual(plan["assemblies"][0]["state"], "hold")
+            self.assertEqual(plan["master"]["state"], "hold")
+
+    def test_ready_hash_mismatch_fails_before_render(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "u1.json").write_text("x", encoding="utf-8")
+            (root / "voices.json").write_text("y", encoding="utf-8")
+            manifest = self.base_manifest()
+            path = root / "production.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ContractError, "mismatch"):
+                production_plan(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #199.

Adds a product-agnostic, executor-neutral Production Manifest v1:
- exact engine commit pin;
- independently renderable units;
- exact Program + voice-pack SHA-256 for ready units;
- explicit provider on every unit, no implicit fallback;
- explicit HOLD units with reason;
- one-and-only-one assembly membership;
- master gating;
- offline `audio-engine production validate`;
- hash-verifying `audio-engine production plan`;
- tests and contract documentation.

No Lab provider is promoted and no Odyssée-specific logic is added.