### PR TITLE
prod: add assembly provenance and QA

### DIFF
--- a/src/audio_engine/assemble.py
+++ b/src/audio_engine/assemble.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import tempfile
 from pathlib import Path
@@ -16,6 +17,7 @@ def assemble_plan(plan_path, output_root):
     output_dir.mkdir(parents=True, exist_ok=True)
     audio_path = output_dir / "audio.mp3"
 
+    input_evidence = []
     with tempfile.TemporaryDirectory() as temp_value:
         temp_dir = Path(temp_value)
         parts = []
@@ -24,17 +26,40 @@ def assemble_plan(plan_path, output_root):
             source = (plan_path.parent / item["file"]).resolve()
             if not source.exists():
                 raise FileNotFoundError(f"Assembly input not found: {source}")
+            duration = probe_duration_seconds(source)
+            if duration is None or duration <= 0:
+                raise RuntimeError(f"Assembly input has no measurable audio duration: {source}")
+            input_evidence.append({
+                "file": item["file"],
+                "sha256": sha256_file(source),
+                "duration_seconds": duration,
+                "pause_after_ms": int(item.get("pause_after_ms", 0)),
+            })
             parts.append(source)
             pause = silence_file(temp_dir, item.get("pause_after_ms", 0), silence_cache)
             if pause:
                 parts.append(pause)
         encode_concat(parts, audio_path, profile)
 
+    engine_code_sha = sha256_file(Path(__file__))
+    fingerprint_payload = {
+        "source_sha256": sha256_file(plan_path),
+        "engine_code_sha256": engine_code_sha,
+        "engine_version": __version__,
+        "profile": profile_name,
+        "inputs": input_evidence,
+    }
+    render_fingerprint = hashlib.sha256(
+        json.dumps(fingerprint_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
     manifest = {
         "schema_version": 1,
         "id": plan["id"],
         "status": "success",
         "source_sha256": sha256_file(plan_path),
+        "engine_code_sha256": engine_code_sha,
+        "render_fingerprint": render_fingerprint,
         "engine_version": __version__,
         "profile": profile_name,
         "audio": {
@@ -46,6 +71,10 @@ def assemble_plan(plan_path, output_root):
             "duration_seconds": probe_duration_seconds(audio_path),
         },
         "inputs": plan["inputs"],
+        "assembly": {
+            "input_count": len(input_evidence),
+            "inputs": input_evidence,
+        },
         "warnings": [],
     }
     (output_dir / "manifest.json").write_text(

--- a/src/audio_engine/qa.py
+++ b/src/audio_engine/qa.py
@@ -161,6 +161,156 @@ def _timeline_checks(manifest, transcript, duration_seconds):
     }
 
 
+
+def _qa_assembly(render_dir, manifest, manifest_path):
+    checks = []
+    audio_name = (manifest.get("audio") or {}).get("file")
+    audio_path = render_dir / audio_name if audio_name else None
+    files_ok = bool(audio_path and audio_path.is_file() and manifest.get("status") == "success")
+    _check(
+        checks,
+        "files",
+        files_ok,
+        "assembly manifest and audio are present" if files_ok else "required assembly files are missing",
+        {"manifest": str(manifest_path), "audio": str(audio_path) if audio_path else None},
+    )
+    if not files_ok:
+        report = {
+            "schema_version": 1,
+            "status": "FAIL",
+            "render_id": manifest.get("id"),
+            "kind": "assembly",
+            "failed_checks": ["files"],
+            "checks": checks,
+        }
+        (render_dir / "qa-report.json").write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return report
+
+    duration = probe_duration_seconds(audio_path)
+    declared_duration = (manifest.get("audio") or {}).get("duration_seconds")
+    duration_ok = (
+        isinstance(duration, (int, float))
+        and duration > 0.2
+        and isinstance(declared_duration, (int, float))
+        and abs(float(duration) - float(declared_duration)) <= 0.15
+    )
+    _check(
+        checks,
+        "duration",
+        duration_ok,
+        "measured duration matches assembly manifest" if duration_ok else "assembly duration is missing or differs",
+        {"measured_seconds": duration, "manifest_seconds": declared_duration},
+    )
+
+    hashes = {
+        "audio_sha256": _sha256(audio_path),
+        "manifest_sha256": _sha256(manifest_path),
+    }
+    _check(checks, "sha256", all(_HASH_RE.fullmatch(v) for v in hashes.values()), "SHA-256 digests computed for assembly evidence", hashes)
+
+    assembly = manifest.get("assembly") or {}
+    inputs = assembly.get("inputs") or []
+    input_count = assembly.get("input_count")
+    inputs_ok = (
+        isinstance(inputs, list)
+        and len(inputs) > 0
+        and input_count == len(inputs)
+        and all(
+            isinstance(item, dict)
+            and _HASH_RE.fullmatch(str(item.get("sha256") or ""))
+            and isinstance(item.get("duration_seconds"), (int, float))
+            and item["duration_seconds"] > 0
+            and isinstance(item.get("file"), str)
+            and bool(item["file"])
+            for item in inputs
+        )
+    )
+    _check(
+        checks,
+        "assembly_inputs",
+        inputs_ok,
+        "assembly inputs are content-hashed and duration-qualified" if inputs_ok else "assembly input evidence is incomplete",
+        {"input_count": input_count, "inputs": inputs},
+    )
+
+    profile_name = manifest.get("profile", "speech")
+    channels = int((manifest.get("audio") or {}).get("channels") or 1)
+    profile = get_profile(profile_name, stereo=channels == 2)
+    loudness = _loudness_metrics(audio_path)
+    clipping_ok = loudness["true_peak_dbtp"] <= -0.1
+    _check(checks, "clipping", clipping_ok, "no near-zero-dBTP clipping detected" if clipping_ok else "true peak is at or near clipping", loudness)
+
+    loudness_delta = abs(loudness["integrated_lufs"] - float(profile["loudness_lufs"]))
+    peak_margin = loudness["true_peak_dbtp"] - float(profile["true_peak_db"])
+    levels_ok = loudness_delta <= 2.0 and peak_margin <= 1.5
+    _check(
+        checks,
+        "levels",
+        levels_ok,
+        "assembly loudness is within production tolerance" if levels_ok else "assembly loudness or true peak is outside tolerance",
+        {
+            **loudness,
+            "target_lufs": profile["loudness_lufs"],
+            "target_true_peak_dbtp": profile["true_peak_db"],
+            "loudness_delta_lu": round(loudness_delta, 3),
+            "true_peak_margin_db": round(peak_margin, 3),
+        },
+    )
+
+    silence = _silence_metrics(audio_path, float(duration or 0))
+    declared_pauses = [float(item.get("pause_after_ms", 0)) for item in inputs if isinstance(item, dict)]
+    allowed_longest = max(4.0, (max(declared_pauses, default=0.0) / 1000.0) + 2.0)
+    silence_ok = silence["longest_seconds"] <= allowed_longest and silence["ratio"] <= 0.55
+    _check(
+        checks,
+        "silence",
+        silence_ok,
+        "no abnormal assembly silence detected" if silence_ok else "abnormal assembly silence detected",
+        {**silence, "allowed_longest_seconds": round(allowed_longest, 3)},
+    )
+
+    provenance = {
+        "source_sha256": manifest.get("source_sha256"),
+        "engine_code_sha256": manifest.get("engine_code_sha256"),
+        "render_fingerprint": manifest.get("render_fingerprint"),
+        "engine_version": manifest.get("engine_version"),
+    }
+    provenance_ok = (
+        all(_HASH_RE.fullmatch(str(provenance[key] or "")) for key in ("source_sha256", "engine_code_sha256", "render_fingerprint"))
+        and bool(provenance["engine_version"])
+        and inputs_ok
+    )
+    _check(
+        checks,
+        "provenance",
+        provenance_ok,
+        "assembly is strongly traceable to plan, engine code and content-hashed inputs" if provenance_ok else "assembly provenance is incomplete",
+        provenance,
+    )
+
+    failed = [check["id"] for check in checks if check["status"] != "PASS"]
+    report = {
+        "schema_version": 1,
+        "status": "PASS" if not failed else "FAIL",
+        "render_id": manifest.get("id"),
+        "kind": "assembly",
+        "failed_checks": failed,
+        "reproducibility": {
+            "grade": "traceable-local-assembly",
+            "bit_exact_rerender_verified": False,
+            "note": "QA binds the assembly to exact input hashes and engine code; it does not claim cross-runtime bit-exact encoder output.",
+        },
+        "checks": checks,
+    }
+    (render_dir / "qa-report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
 def qa_render(render_dir):
     render_dir = Path(render_dir)
     checks = []
@@ -168,6 +318,8 @@ def qa_render(render_dir):
     if not manifest_path.is_file():
         raise FileNotFoundError(f"Missing render manifest: {manifest_path}")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("assembly") is not None and not manifest.get("transcript"):
+        return _qa_assembly(render_dir, manifest, manifest_path)
 
     audio_name = (manifest.get("audio") or {}).get("file")
     transcript_name = manifest.get("transcript")

--- a/tests/test_assembly_qa.py
+++ b/tests/test_assembly_qa.py
@@ -1,0 +1,70 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from audio_engine.assemble import assemble_plan
+from audio_engine.qa import qa_render
+
+
+class AssemblyProvenanceQATests(unittest.TestCase):
+    def test_assembly_manifest_hashes_inputs_and_qa_accepts_complete_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "scene.mp3"
+            source.write_bytes(b"scene-audio")
+            plan = root / "block.json"
+            plan.write_text(json.dumps({
+                "schema_version": 1,
+                "id": "block-a",
+                "inputs": [{"file": "scene.mp3", "pause_after_ms": 0}],
+            }), encoding="utf-8")
+
+            def fake_concat(parts, output_path, profile):
+                Path(output_path).write_bytes(b"assembled-audio")
+
+            with (
+                patch("audio_engine.assemble.probe_duration_seconds", return_value=1.25),
+                patch("audio_engine.assemble.encode_concat", side_effect=fake_concat),
+            ):
+                manifest = assemble_plan(plan, root / "out")
+
+            render_dir = root / "out" / "block-a"
+            self.assertEqual(manifest["assembly"]["input_count"], 1)
+            self.assertEqual(len(manifest["assembly"]["inputs"][0]["sha256"]), 64)
+            self.assertEqual(len(manifest["engine_code_sha256"]), 64)
+            self.assertEqual(len(manifest["render_fingerprint"]), 64)
+
+            with (
+                patch("audio_engine.qa.probe_duration_seconds", return_value=1.25),
+                patch(
+                    "audio_engine.qa._loudness_metrics",
+                    return_value={
+                        "integrated_lufs": -16.0,
+                        "true_peak_dbtp": -2.5,
+                        "lra_lu": 4.0,
+                        "threshold_lufs": -26.0,
+                    },
+                ),
+                patch(
+                    "audio_engine.qa._silence_metrics",
+                    return_value={
+                        "threshold_db": -45,
+                        "minimum_event_seconds": 0.8,
+                        "interval_count": 0,
+                        "total_seconds": 0.0,
+                        "longest_seconds": 0.0,
+                        "ratio": 0.0,
+                        "intervals": [],
+                    },
+                ),
+            ):
+                report = qa_render(render_dir)
+            self.assertEqual(report["status"], "PASS")
+            self.assertEqual(report["kind"], "assembly")
+            self.assertIn("assembly_inputs", [check["id"] for check in report["checks"]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Advances #200 and unblocks #201.

Adds generic block/master assembly evidence:
- SHA-256 and measured duration for every assembly input;
- assembly engine-code hash and deterministic render fingerprint;
- automatic QA mode for assemblies;
- duration, clipping, loudness, silence, input evidence and provenance checks;
- no product-specific logic.

This creates the trustworthy fan-in boundary needed for blocks and masters.