### PR TITLE
prod: add fail-closed multi-provider segment routing

### DIFF
--- a/src/audio_engine/contract.py
+++ b/src/audio_engine/contract.py
@@ -309,6 +309,12 @@ def validate_program(program):
                 errors.append(f"segments[{index}] needs voice, preset, or target")
             if "provider" in segment and not _non_empty_string(segment.get("provider")):
                 errors.append(f"segments[{index}].provider must be a non-empty string")
+            if "provider_parameters" in segment and not isinstance(segment.get("provider_parameters"), dict):
+                errors.append(f"segments[{index}].provider_parameters must be an object")
+            if "provider_seed" in segment:
+                seed = segment.get("provider_seed")
+                if not isinstance(seed, int) or isinstance(seed, bool) or seed < 0:
+                    errors.append(f"segments[{index}].provider_seed must be a non-negative integer")
             pause = segment.get("pause_after_ms", 350)
             if not isinstance(pause, (int, float)) or pause < 0:
                 errors.append(f"segments[{index}].pause_after_ms must be >= 0")

--- a/src/audio_engine/contract.py
+++ b/src/audio_engine/contract.py
@@ -307,6 +307,8 @@ def validate_program(program):
                 errors.append(f"segments[{index}].text is required")
             if not (segment.get("voice") or segment.get("preset") or segment.get("target")):
                 errors.append(f"segments[{index}] needs voice, preset, or target")
+            if "provider" in segment and not _non_empty_string(segment.get("provider")):
+                errors.append(f"segments[{index}].provider must be a non-empty string")
             pause = segment.get("pause_after_ms", 350)
             if not isinstance(pause, (int, float)) or pause < 0:
                 errors.append(f"segments[{index}].pause_after_ms must be >= 0")

--- a/src/audio_engine/providers/registry.py
+++ b/src/audio_engine/providers/registry.py
@@ -1,0 +1,50 @@
+from .edge import EdgeProvider
+
+
+class ProviderRegistry:
+    """Small explicit registry for Production synthesis providers.
+
+    Registration is dependency injection, not discovery. The engine never scans
+    installed packages and never falls back to another provider.
+    """
+
+    def __init__(self, providers=None, include_edge=True):
+        self._providers = {}
+        if include_edge:
+            self.register(EdgeProvider())
+        for key, provider in (providers or {}).items():
+            if getattr(provider, "name", None) != key:
+                raise ValueError(
+                    f"Provider registry key {key!r} differs from provider.name "
+                    f"{getattr(provider, 'name', None)!r}"
+                )
+            self.register(provider)
+
+    def register(self, provider):
+        name = getattr(provider, "name", None)
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("Provider must expose a non-empty name")
+        if name in self._providers:
+            raise ValueError(f"Duplicate provider registration: {name}")
+        self._providers[name] = provider
+        return provider
+
+    def get(self, name):
+        try:
+            return self._providers[name]
+        except KeyError as exc:
+            available = ", ".join(sorted(self._providers)) or "none"
+            raise ValueError(
+                f"Production provider {name!r} is unavailable; registered providers: {available}. "
+                "No fallback is allowed."
+            ) from exc
+
+    def records(self, names):
+        records = []
+        for name in sorted(set(names)):
+            provider = self.get(name)
+            records.append({
+                "name": name,
+                "processing": getattr(provider, "processing", "unknown"),
+            })
+        return records

--- a/src/audio_engine/render.py
+++ b/src/audio_engine/render.py
@@ -10,13 +10,13 @@ from .audio import probe_duration_seconds
 from .contract import load_json, sha256_file, validate_program
 from .mix.render import render_master, render_speech_track, stereo_required
 from .profiles import get_profile
-from .providers.edge import EdgeProvider
+from .providers.registry import ProviderRegistry
 from .sound.render import (
     render_soundscape,
     scene_space_requirements,
     soundscape_source_sha256,
 )
-from .voice.render import render_voice_clip, voice_content_key
+from .voice.render import provider_cache_identity, render_voice_clip, voice_content_key
 from .voices import load_voice_config, resolve_segments
 
 
@@ -31,6 +31,7 @@ def engine_code_sha256():
         root / "profiles.py",
         root / "voices.py",
         root / "providers" / "edge.py",
+        root / "providers" / "registry.py",
         root / "voice" / "render.py",
         root / "ambience" / "prepare.py",
         root / "sound" / "catalog.py",
@@ -47,7 +48,7 @@ def render_fingerprint(
     source_sha,
     voice_config_sha,
     engine_code_sha,
-    provider_name,
+    provider_records,
     profile_name,
     ambience_source_sha=None,
     soundscape_source_sha=None,
@@ -56,7 +57,7 @@ def render_fingerprint(
         "source_sha256": source_sha,
         "voice_config_sha256": voice_config_sha,
         "engine_code_sha256": engine_code_sha,
-        "provider": provider_name,
+        "providers": provider_records,
         "profile": profile_name,
         "ambience_source_sha256": ambience_source_sha,
         "soundscape_source_sha256": soundscape_source_sha,
@@ -87,12 +88,8 @@ def cached_manifest(output_dir, expected_fingerprint):
     return manifest
 
 
-def _previous_voice_cache_map(output_dir, provider_name):
-    """Map unchanged synthesis content to prior fingerprints from the last output.
-
-    This lets a new engine/cache-wrapper release re-key existing dry voice clips
-    locally instead of calling the remote TTS provider again.
-    """
+def _previous_voice_cache_map(output_dir):
+    """Map unchanged synthesis content to prior fingerprints across providers."""
     manifest_path = Path(output_dir) / "manifest.json"
     transcript_path = Path(output_dir) / "transcript.json"
     if not manifest_path.exists() or not transcript_path.exists():
@@ -102,21 +99,24 @@ def _previous_voice_cache_map(output_dir, provider_name):
         transcript = json.loads(transcript_path.read_text(encoding="utf-8"))
     except Exception:
         return {}
-    if (manifest.get("provider") or {}).get("name") != provider_name:
-        return {}
+    default_provider = (manifest.get("provider") or {}).get("name")
     fingerprints = (manifest.get("mix") or {}).get("voice_fingerprints") or []
     segments = transcript.get("segments") or []
     if len(fingerprints) != len(segments):
         return {}
     result = {}
     for segment, fingerprint in zip(segments, fingerprints):
-        if isinstance(segment, dict) and isinstance(fingerprint, str) and fingerprint:
-            try:
-                result.setdefault(voice_content_key(segment, provider_name), []).append(fingerprint)
-            except (KeyError, TypeError):
-                continue
+        if not isinstance(segment, dict) or not isinstance(fingerprint, str) or not fingerprint:
+            continue
+        provider_name = segment.get("provider") or default_provider
+        if not provider_name or provider_name == "multi":
+            continue
+        try:
+            key = (provider_name, voice_content_key(segment, provider_name))
+            result.setdefault(key, []).append(fingerprint)
+        except (KeyError, TypeError):
+            continue
     return result
-
 
 def _resolve_relative_sound_intent(soundscape, schema_version, timeline):
     if schema_version < 6 or not soundscape:
@@ -159,14 +159,46 @@ def _resolve_relative_sound_intent(soundscape, schema_version, timeline):
     return resolved, resolutions
 
 
-def render_program(program_path, output_root, voices_path=None, provider=None, sounds_path=None):
+def render_program(
+    program_path,
+    output_root,
+    voices_path=None,
+    provider=None,
+    providers=None,
+    sounds_path=None,
+):
     program_path = Path(program_path)
     program = validate_program(load_json(program_path))
     profile_name = program.get("profile", "speech")
     needs_stereo = stereo_required(program)
     profile = get_profile(profile_name, stereo=needs_stereo)
     voice_config, voice_config_path = load_voice_config(voices_path)
-    provider = provider or EdgeProvider()
+    resolved = resolve_segments(program, voice_config)
+
+    if provider is not None and providers is not None:
+        raise ValueError("Use provider or providers, not both")
+    if provider is not None:
+        declared = {segment["provider"] for segment in resolved}
+        if declared - {"edge", provider.name}:
+            raise ValueError(
+                f"Single-provider injection {provider.name!r} cannot satisfy declared providers "
+                f"{sorted(declared)}"
+            )
+        resolved = [{**segment, "provider": provider.name} for segment in resolved]
+        registry = ProviderRegistry({provider.name: provider}, include_edge=False)
+    else:
+        registry = ProviderRegistry(providers or {}, include_edge=True)
+
+    provider_names = sorted({segment["provider"] for segment in resolved})
+    provider_objects = {name: registry.get(name) for name in provider_names}
+    provider_records = [
+        {
+            "name": name,
+            "processing": getattr(provider_objects[name], "processing", "unknown"),
+            "cache_identity": provider_cache_identity(provider_objects[name]),
+        }
+        for name in provider_names
+    ]
 
     source_sha = sha256_file(program_path)
     voice_config_sha = sha256_file(voice_config_path)
@@ -183,7 +215,7 @@ def render_program(program_path, output_root, voices_path=None, provider=None, s
         source_sha,
         voice_config_sha,
         engine_sha,
-        provider.name,
+        provider_records,
         profile_name,
         ambience_sha,
         soundscape_sha,
@@ -196,19 +228,23 @@ def render_program(program_path, output_root, voices_path=None, provider=None, s
     if cached:
         return {**cached, "cache_hit": True}
 
-    previous_voice_cache = _previous_voice_cache_map(output_dir, provider.name)
-    resolved = resolve_segments(program, voice_config)
+    previous_voice_cache = _previous_voice_cache_map(output_dir)
     voice_cache_root = output_root / ".cache" / "voices"
     voice_clips = []
     voice_cache_hits = 0
     voice_fingerprints = []
     for segment in resolved:
+        segment_provider = provider_objects[segment["provider"]]
         fallback_fingerprints = previous_voice_cache.get(
-            voice_content_key(segment, provider.name), []
+            (
+                segment_provider.name,
+                voice_content_key(segment, segment_provider.name),
+            ),
+            [],
         )
         clip, cache_hit, voice_fingerprint = render_voice_clip(
             segment,
-            provider,
+            segment_provider,
             voice_cache_root,
             fallback_fingerprints=fallback_fingerprints,
         )
@@ -312,10 +348,15 @@ def render_program(program_path, output_root, voices_path=None, provider=None, s
         "engine_code_sha256": engine_sha,
         "render_fingerprint": fingerprint,
         "engine_version": __version__,
-        "provider": {
-            "name": provider.name,
-            "processing": getattr(provider, "processing", "unknown"),
-        },
+        "provider": (
+            {
+                "name": provider_records[0]["name"],
+                "processing": provider_records[0]["processing"],
+            }
+            if len(provider_records) == 1
+            else {"name": "multi", "processing": "mixed"}
+        ),
+        "providers": provider_records,
         "profile": profile_name,
         "audio": {
             "file": "audio.mp3",
@@ -330,6 +371,7 @@ def render_program(program_path, output_root, voices_path=None, provider=None, s
             "voice_clip_count": len(resolved),
             "voice_cache_hits": voice_cache_hits,
             "voice_fingerprints": voice_fingerprints,
+            "voice_providers": [segment["provider"] for segment in resolved],
             "ambience": ambience_manifest,
             "ambience_cache_hit": ambience_cache_hit,
             "soundscape": soundscape_manifest,

--- a/src/audio_engine/voice/render.py
+++ b/src/audio_engine/voice/render.py
@@ -40,6 +40,8 @@ def voice_content_key(segment, provider_name):
         "rate": segment.get("rate", "+0%"),
         "pitch": segment.get("pitch", "+0Hz"),
         "volume": segment.get("volume", "+0%"),
+        "provider_parameters": segment.get("provider_parameters"),
+        "provider_seed": segment.get("provider_seed"),
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 

--- a/src/audio_engine/voice/render.py
+++ b/src/audio_engine/voice/render.py
@@ -46,15 +46,27 @@ def voice_content_key(segment, provider_name):
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
+def provider_cache_identity(provider):
+    """Stable provider runtime identity used by clip and scene caches."""
+    explicit = getattr(provider, "cache_identity", None)
+    if callable(explicit):
+        explicit = explicit()
+    if explicit is None:
+        explicit = _provider_code_sha256(provider)
+    return str(explicit)
+
+
 def voice_fingerprint(segment, provider):
     payload = {
         "provider": provider.name,
-        "provider_code_sha256": _provider_code_sha256(provider),
+        "provider_cache_identity": provider_cache_identity(provider),
         "text": segment["text"],
         "voice": segment["voice"],
         "rate": segment.get("rate", "+0%"),
         "pitch": segment.get("pitch", "+0Hz"),
         "volume": segment.get("volume", "+0%"),
+        "provider_parameters": segment.get("provider_parameters"),
+        "provider_seed": segment.get("provider_seed"),
     }
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/src/audio_engine/voices.py
+++ b/src/audio_engine/voices.py
@@ -145,8 +145,9 @@ def choose_preset(target, presets):
     return ranked[0][1], ranked
 
 
-def _identity_from_resolution(voice, rate, pitch, volume, resolved_preset):
+def _identity_from_resolution(provider, voice, rate, pitch, volume, resolved_preset):
     return {
+        "provider": provider,
         "voice": voice,
         "rate": rate,
         "pitch": pitch,
@@ -162,12 +163,14 @@ def resolve_segments(program, voice_config):
     resolved = []
     for index, segment in enumerate(program["segments"], start=1):
         explicit_voice = segment.get("voice")
+        explicit_provider = segment.get("provider")
         preset_id = segment.get("preset")
         explicit_character_id = segment.get("character_id")
         character_id = explicit_character_id or f"segment-{index}"
         alternatives = []
 
         if explicit_voice:
+            provider = explicit_provider or "edge"
             voice = explicit_voice
             rate = segment.get("rate", "+0%")
             pitch = segment.get("pitch", "+0Hz")
@@ -177,6 +180,12 @@ def resolve_segments(program, voice_config):
             if preset_id not in by_id:
                 raise ValueError(f"Unknown voice preset: {preset_id}")
             preset = by_id[preset_id]
+            provider = preset.get("provider", "edge")
+            if explicit_provider and explicit_provider != provider:
+                raise ValueError(
+                    f"Segment provider {explicit_provider!r} conflicts with preset "
+                    f"{preset_id!r} provider {provider!r}"
+                )
             voice = preset["voice"]
             rate = segment.get("rate", preset.get("rate", "+0%"))
             pitch = segment.get("pitch", preset.get("pitch", "+0Hz"))
@@ -184,6 +193,12 @@ def resolve_segments(program, voice_config):
             resolved_preset = preset["id"]
         elif explicit_character_id and character_id in character_cast:
             identity = character_cast[character_id]
+            provider = identity["provider"]
+            if explicit_provider and explicit_provider != provider:
+                raise ValueError(
+                    f"Character {character_id!r} cannot silently change provider "
+                    f"from {provider!r} to {explicit_provider!r}"
+                )
             voice = identity["voice"]
             rate = segment.get("rate", identity["rate"])
             pitch = segment.get("pitch", identity["pitch"])
@@ -191,6 +206,12 @@ def resolve_segments(program, voice_config):
             resolved_preset = identity["resolved_preset"]
         else:
             preset, ranked = choose_preset(segment.get("target", {}), presets)
+            provider = preset.get("provider", "edge")
+            if explicit_provider and explicit_provider != provider:
+                raise ValueError(
+                    f"Segment provider {explicit_provider!r} conflicts with selected preset "
+                    f"{preset['id']!r} provider {provider!r}"
+                )
             voice = preset["voice"]
             rate = segment.get("rate", preset.get("rate", "+0%"))
             pitch = segment.get("pitch", preset.get("pitch", "+0Hz"))
@@ -203,26 +224,27 @@ def resolve_segments(program, voice_config):
 
         if explicit_character_id:
             previous = character_cast.get(character_id)
-            if previous and previous["voice"] != voice:
+            if previous and (previous["provider"] != provider or previous["voice"] != voice):
                 raise ValueError(
-                    f"Character {character_id!r} cannot silently change provider voice "
-                    f"from {previous['voice']} to {voice}; use a distinct age incarnation until "
-                    "an age lineage has been explicitly qualified"
+                    f"Character {character_id!r} cannot silently change provider identity "
+                    f"from {previous['provider']}:{previous['voice']} to {provider}:{voice}; "
+                    "use a distinct age incarnation until an age lineage has been explicitly qualified"
                 )
             if previous is None:
                 character_cast[character_id] = _identity_from_resolution(
-                    voice, rate, pitch, volume, resolved_preset
+                    provider, voice, rate, pitch, volume, resolved_preset
                 )
 
         resolved.append({
             **segment,
             "sequence": index,
             "resolved_preset": resolved_preset,
+            "provider": provider,
             "voice": voice,
             "rate": rate,
             "pitch": pitch,
             "volume": volume,
-            "casting_identity": voice if explicit_character_id else None,
+            "casting_identity": f"{provider}:{voice}" if explicit_character_id else None,
             "casting_alternatives": alternatives,
         })
     return resolved

--- a/tests/test_multi_provider.py
+++ b/tests/test_multi_provider.py
@@ -1,0 +1,144 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from audio_engine.audio import run_ffmpeg
+from audio_engine.render import render_program
+from audio_engine.voices import resolve_segments
+
+
+class ToneProvider:
+    processing = "local-test"
+
+    def __init__(self, name, frequency):
+        self.name = name
+        self.frequency = frequency
+        self.calls = 0
+
+    def cache_identity(self):
+        return f"{self.name}-runtime-v1"
+
+    def synthesize(self, segment, path):
+        self.calls += 1
+        run_ffmpeg([
+            "-f", "lavfi",
+            "-i", f"sine=frequency={self.frequency}:sample_rate=24000:duration=0.20",
+            "-ac", "1",
+            "-c:a", "libmp3lame",
+            "-b:a", "64k",
+            str(path),
+        ])
+
+
+class MultiProviderRoutingTests(unittest.TestCase):
+    def write_program(self, root, data):
+        path = Path(root) / "program.json"
+        path.write_text(json.dumps(data), encoding="utf-8")
+        return path
+
+    def test_routes_each_segment_to_declared_provider(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            program = self.write_program(root, {
+                "schema_version": 1,
+                "id": "multi",
+                "title": "Multi provider",
+                "segments": [
+                    {"provider": "alpha", "voice": "voice-a", "text": "Alpha."},
+                    {"provider": "beta", "voice": "voice-b", "text": "Beta."},
+                ],
+            })
+            alpha = ToneProvider("alpha", 440)
+            beta = ToneProvider("beta", 550)
+            manifest = render_program(
+                program,
+                root / "out",
+                providers={"alpha": alpha, "beta": beta},
+            )
+            self.assertEqual(alpha.calls, 1)
+            self.assertEqual(beta.calls, 1)
+            self.assertEqual(manifest["provider"]["name"], "multi")
+            self.assertEqual(
+                [item["name"] for item in manifest["providers"]],
+                ["alpha", "beta"],
+            )
+            self.assertEqual(manifest["mix"]["voice_providers"], ["alpha", "beta"])
+            transcript = json.loads(
+                (root / "out" / "multi" / "transcript.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                [item["provider"] for item in transcript["segments"]],
+                ["alpha", "beta"],
+            )
+
+    def test_missing_declared_provider_fails_before_synthesis(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            program = self.write_program(root, {
+                "schema_version": 1,
+                "id": "missing",
+                "title": "Missing provider",
+                "segments": [
+                    {"provider": "alpha", "voice": "voice-a", "text": "Alpha."},
+                    {"provider": "missing", "voice": "voice-b", "text": "Missing."},
+                ],
+            })
+            alpha = ToneProvider("alpha", 440)
+            with self.assertRaisesRegex(ValueError, "Production provider 'missing' is unavailable"):
+                render_program(program, root / "out", providers={"alpha": alpha})
+            self.assertEqual(alpha.calls, 0)
+
+    def test_provider_parameters_and_seed_change_voice_cache_identity(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data = {
+                "schema_version": 1,
+                "id": "controls",
+                "title": "Provider controls",
+                "segments": [{
+                    "provider": "alpha",
+                    "voice": "voice-a",
+                    "text": "Controlled.",
+                    "provider_seed": 42,
+                    "provider_parameters": {"temperature": 0.7},
+                }],
+            }
+            program = self.write_program(root, data)
+            alpha = ToneProvider("alpha", 440)
+            first = render_program(program, root / "out", providers={"alpha": alpha})
+            first_fp = first["mix"]["voice_fingerprints"][0]
+            self.assertEqual(alpha.calls, 1)
+
+            data["segments"][0]["provider_parameters"]["temperature"] = 0.8
+            program.write_text(json.dumps(data), encoding="utf-8")
+            second = render_program(program, root / "out", providers={"alpha": alpha})
+            self.assertEqual(alpha.calls, 2)
+            self.assertNotEqual(first_fp, second["mix"]["voice_fingerprints"][0])
+
+    def test_character_provider_identity_cannot_change_silently(self):
+        program = {
+            "schema_version": 1,
+            "id": "continuity",
+            "title": "Continuity",
+            "segments": [
+                {
+                    "character_id": "hero",
+                    "provider": "alpha",
+                    "voice": "voice-a",
+                    "text": "Première ligne.",
+                },
+                {
+                    "character_id": "hero",
+                    "provider": "beta",
+                    "voice": "voice-a",
+                    "text": "Deuxième ligne.",
+                },
+            ],
+        }
+        with self.assertRaisesRegex(ValueError, "cannot silently change provider"):
+            resolve_segments(program, {"presets": []})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Continues #202 without promoting any specific ML provider.

Adds generic Production semantics:
- optional provider id per segment/preset;
- explicit provider registry, no discovery and no fallback;
- per-segment provider routing in one Program;
- provider identity included in scene/clip fingerprints;
- provider synthesis parameters + seed included in voice cache identity;
- character continuity binds provider+voice, preventing silent recast;
- backward-compatible single-provider injection for tests/local callers;
- multi-provider manifest evidence.

Tests cover mixed providers, missing-provider fail-before-synthesis, cache separation by seed/parameters, and provider continuity.