### PR TITLE
prod: fix production hydrate-assets CLI dispatch

### DIFF
--- a/src/audio_engine/cli.py
+++ b/src/audio_engine/cli.py
@@ -331,8 +331,17 @@ def main(argv=None):
                     workspace_root=args.workspace_root,
                     verify_files=args.verify_files,
                 )
+            elif args.production_command == "plan":
+                result = production_plan(
+                    args.manifest,
+                    workspace_root=args.workspace_root,
+                )
             else:
-                result = production_plan(args.manifest, workspace_root=args.workspace_root)
+                result = hydrate_production_unit_assets(
+                    args.manifest,
+                    args.unit,
+                    workspace_root=args.workspace_root,
+                )
         elif args.command == "provider-package":
             if args.provider_package_command == "validate":
                 result = provider_package_report(

--- a/tests/test_cli_production_assets.py
+++ b/tests/test_cli_production_assets.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import patch
+
+from audio_engine.cli import main
+
+
+class ProductionAssetsCliTests(unittest.TestCase):
+    def test_hydrate_assets_dispatches_to_asset_hydrator(self):
+        expected = {
+            "schema_version": 1,
+            "status": "ready",
+            "unit_id": "S08",
+            "assets": [],
+        }
+        with patch(
+            "audio_engine.cli.hydrate_production_unit_assets",
+            return_value=expected,
+        ) as hydrate:
+            rc = main([
+                "production",
+                "hydrate-assets",
+                "manifest.json",
+                "--unit",
+                "S08",
+                "--workspace-root",
+                ".",
+            ])
+        self.assertEqual(rc, 0)
+        hydrate.assert_called_once_with(
+            "manifest.json",
+            "S08",
+            workspace_root=".",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the defect exposed by Odyssée S08 production run 33515424121.

The parser already exposed `production hydrate-assets`, but the command dispatcher still treated every non-`validate` subcommand as `production plan`. As a result, the workflow reported the plan instead of materializing the locked dark-air asset, and S08 later failed with a missing ambience file.

This patch:
- dispatches `plan` explicitly;
- dispatches `hydrate-assets` to `hydrate_production_unit_assets`;
- adds a regression test binding the CLI call to the hydrator.

No provider, synthesis, cache or artistic behavior changes.