### PR TITLE
prod: promote Chatterbox ffmpeg/ffprobe system runtime

### DIFF
--- a/scripts/install_chatterbox_mtl_v3_h1b.sh
+++ b/scripts/install_chatterbox_mtl_v3_h1b.sh
@@ -11,6 +11,25 @@ if sys.version_info[:3] != expected:
     )
 PY
 
+# H1b authority job 99322452235 installed Ubuntu ffmpeg
+# 7:6.1.1-3ubuntu5, which supplies both ffmpeg and ffprobe. Production
+# provisions the same declared capability and records the actual runner version.
+if ! command -v ffmpeg >/dev/null 2>&1 || ! command -v ffprobe >/dev/null 2>&1; then
+  if ! command -v apt-get >/dev/null 2>&1; then
+    echo "ERROR: Chatterbox H1b runtime requires ffmpeg + ffprobe; no supported provisioner is available." >&2
+    exit 2
+  fi
+  sudo apt-get update
+  sudo apt-get install -y ffmpeg
+fi
+
+ffmpeg -version | head -n 1
+ffprobe -version | head -n 1
+if command -v dpkg-query >/dev/null 2>&1; then
+  printf 'CHATTERBOX_SYSTEM_FFMPEG_PACKAGE='
+  dpkg-query -W -f='${Version}\n' ffmpeg
+fi
+
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 python -m pip install --disable-pip-version-check \
   -r "$root/requirements/chatterbox-mtl-v3-h1b-runtime.txt"

--- a/src/audio_engine/provider_package.py
+++ b/src/audio_engine/provider_package.py
@@ -80,6 +80,29 @@ def validate_provider_package(package, package_path=None, workspace_root=".", ve
                 if has_revision and not _GIT_SHA_RE.fullmatch(dep["revision"]):
                     errors.append(f"runtime.dependencies[{i}].revision must be an exact 40-char Git SHA")
 
+        system_dependencies = runtime.get("system_dependencies", [])
+        if not isinstance(system_dependencies, list):
+            errors.append("runtime.system_dependencies must be an array")
+        else:
+            seen_system = set()
+            for i, dep in enumerate(system_dependencies, 1):
+                label = f"runtime.system_dependencies[{i}]"
+                if not isinstance(dep, dict) or not _non_empty(dep.get("name")):
+                    errors.append(f"{label}.name is required")
+                    continue
+                if dep["name"] in seen_system:
+                    errors.append(f"duplicate system dependency: {dep['name']}")
+                seen_system.add(dep["name"])
+                commands = dep.get("commands")
+                if (
+                    not isinstance(commands, list)
+                    or not commands
+                    or not all(_non_empty(command) for command in commands)
+                ):
+                    errors.append(f"{label}.commands must be a non-empty array of command names")
+                if "reference_version" in dep and not _non_empty(dep.get("reference_version")):
+                    errors.append(f"{label}.reference_version must be a non-empty string")
+
     model = package.get("model")
     if not isinstance(model, dict):
         errors.append("model must be an object")
@@ -218,6 +241,7 @@ def provider_package_report(path, workspace_root=".", verify_files=False, voice_
         "model_revision": package["model"]["revision"],
         "model_integrity_items": len(package["model"]["integrity"]),
         "reference_count": len(package.get("references", [])),
+        "system_dependency_count": len(package["runtime"].get("system_dependencies", [])),
         "seed": package["synthesis"]["seed"],
         "files_verified": bool(verify_files),
     }

--- a/src/audio_engine/providers/chatterbox_mtl_v3.py
+++ b/src/audio_engine/providers/chatterbox_mtl_v3.py
@@ -2,6 +2,8 @@ import hashlib
 import json
 import os
 import random
+import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -55,6 +57,7 @@ class ChatterboxMultilingualV3Provider:
             )
         runtime = self.package["runtime"]
         self.device = runtime.get("device", "cpu")
+        self.system_runtime = self._verify_system_runtime(runtime)
         if self.device != "cpu":
             raise ContractError(
                 "chatterbox-multilingual-v3 Production v1 is qualified for device='cpu' only"
@@ -72,6 +75,40 @@ class ChatterboxMultilingualV3Provider:
         self._model_factory = model_factory
         self._model = None
 
+    def _verify_system_runtime(self, runtime):
+        evidence = []
+        for item in runtime.get("system_dependencies", []):
+            commands = []
+            for command in item["commands"]:
+                executable = shutil.which(command)
+                if not executable:
+                    raise ContractError(
+                        f"Chatterbox system runtime command is unavailable: {command!r}"
+                    )
+                probe = subprocess.run(
+                    [executable, "-version"],
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    check=False,
+                )
+                first_line = (probe.stdout or "").splitlines()[:1]
+                if probe.returncode != 0 or not first_line:
+                    raise ContractError(
+                        f"Chatterbox system runtime version probe failed: {command!r}"
+                    )
+                commands.append({
+                    "command": command,
+                    "executable": executable,
+                    "version": first_line[0].strip(),
+                })
+            evidence.append({
+                "name": item["name"],
+                "reference_version": item.get("reference_version"),
+                "commands": commands,
+            })
+        return evidence
+
     def cache_identity(self):
         payload = {
             "provider": self.name,
@@ -85,6 +122,7 @@ class ChatterboxMultilingualV3Provider:
                 for item in self.package.get("references", [])
             ],
             "device": self.device,
+            "system_runtime": self.system_runtime,
         }
         return hashlib.sha256(
             json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/tests/test_chatterbox_provider.py
+++ b/tests/test_chatterbox_provider.py
@@ -72,6 +72,59 @@ class ChatterboxProviderTests(unittest.TestCase):
         package_path.write_text(json.dumps(package), encoding="utf-8")
         return package_path, model, package
 
+    def test_missing_declared_system_runtime_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_path, model, package = self.make_fixture(tmp)
+            package["runtime"]["system_dependencies"] = [{
+                "name": "ffmpeg",
+                "commands": ["ffmpeg", "ffprobe"],
+                "reference_version": "7:6.1.1-3ubuntu5",
+            }]
+            package_path.write_text(json.dumps(package), encoding="utf-8")
+            with patch(
+                "audio_engine.providers.chatterbox_mtl_v3.shutil.which",
+                side_effect=lambda command: None if command == "ffprobe" else "/usr/bin/ffmpeg",
+            ):
+                with self.assertRaisesRegex(
+                    ContractError,
+                    "system runtime command is unavailable: 'ffprobe'",
+                ):
+                    ChatterboxMultilingualV3Provider(
+                        package_path,
+                        workspace_root=tmp,
+                        model_dir=model,
+                    )
+
+    def test_system_runtime_version_participates_in_cache_identity(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_path, model, package = self.make_fixture(tmp)
+            package["runtime"]["system_dependencies"] = [{
+                "name": "ffmpeg",
+                "commands": ["ffmpeg", "ffprobe"],
+                "reference_version": "7:6.1.1-3ubuntu5",
+            }]
+            package_path.write_text(json.dumps(package), encoding="utf-8")
+
+            def make_provider(version):
+                fake = types.SimpleNamespace(returncode=0, stdout=version + "\n")
+                with patch(
+                    "audio_engine.providers.chatterbox_mtl_v3.shutil.which",
+                    side_effect=lambda command: f"/usr/bin/{command}",
+                ), patch(
+                    "audio_engine.providers.chatterbox_mtl_v3.subprocess.run",
+                    return_value=fake,
+                ):
+                    return ChatterboxMultilingualV3Provider(
+                        package_path,
+                        workspace_root=tmp,
+                        model_dir=model,
+                        model_factory=lambda *_: object(),
+                    )
+
+            first = make_provider("ffmpeg version 6.1.1")
+            second = make_provider("ffmpeg version 6.1.2")
+            self.assertNotEqual(first.cache_identity(), second.cache_identity())
+
     def test_init_verifies_model_and_reference_assets(self):
         with tempfile.TemporaryDirectory() as tmp:
             package_path, model, _ = self.make_fixture(tmp)

--- a/tests/test_chatterbox_provider.py
+++ b/tests/test_chatterbox_provider.py
@@ -81,9 +81,16 @@ class ChatterboxProviderTests(unittest.TestCase):
                 "reference_version": "7:6.1.1-3ubuntu5",
             }]
             package_path.write_text(json.dumps(package), encoding="utf-8")
+            fake_probe = types.SimpleNamespace(
+                returncode=0,
+                stdout="ffmpeg version 6.1.1\n",
+            )
             with patch(
                 "audio_engine.providers.chatterbox_mtl_v3.shutil.which",
                 side_effect=lambda command: None if command == "ffprobe" else "/usr/bin/ffmpeg",
+            ), patch(
+                "audio_engine.providers.chatterbox_mtl_v3.subprocess.run",
+                return_value=fake_probe,
             ):
                 with self.assertRaisesRegex(
                     ContractError,

--- a/tests/test_provider_package.py
+++ b/tests/test_provider_package.py
@@ -57,6 +57,28 @@ class ProviderPackageTests(unittest.TestCase):
         with self.assertRaisesRegex(ContractError, "exact 40-char Git SHA"):
             validate_provider_package(package)
 
+    def test_system_dependency_requires_commands(self):
+        package = self.package()
+        package["runtime"]["system_dependencies"] = [
+            {"name": "ffmpeg", "reference_version": "7:6.1.1-3ubuntu5"}
+        ]
+        with self.assertRaisesRegex(ContractError, "commands must be a non-empty array"):
+            validate_provider_package(package)
+
+    def test_system_dependency_reported_when_declared(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package = self.package()
+            package["runtime"]["system_dependencies"] = [{
+                "name": "ffmpeg",
+                "commands": ["ffmpeg", "ffprobe"],
+                "reference_version": "7:6.1.1-3ubuntu5",
+            }]
+            path = root / "provider.json"
+            path.write_text(json.dumps(package), encoding="utf-8")
+            report = provider_package_report(path)
+            self.assertEqual(report["system_dependency_count"], 1)
+
     def test_hydrate_exact_huggingface_snapshot_and_verify_hashes(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
Completes the H1b runtime promotion exposed by Odyssée S08 production.

Accepted H1b job 99322452235 explicitly installed Ubuntu ffmpeg (7:6.1.1-3ubuntu5), which also supplies ffprobe. The promoted Production runtime previously froze Python/VCS/model/reference state but omitted this system capability.

This change:
- adds optional fail-closed system dependencies to provider-package v1;
- lets packages declare required command names and reference version;
- verifies required commands when a promoted Chatterbox provider is constructed;
- records actual command path/version in provider cache identity/provenance;
- provisions ffmpeg+ffprobe in the exact H1b runtime installer when absent;
- fails explicitly if no supported provisioner exists;
- adds contract and runtime regression tests.

No synthesis parameters, voice, seed, conditioning reference, model weights or product-specific logic change.