### PR TITLE
prod: bound assembly MP3 true-peak correction

### DIFF
--- a/src/audio_engine/assemble.py
+++ b/src/audio_engine/assemble.py
@@ -39,7 +39,7 @@ def assemble_plan(plan_path, output_root):
             pause = silence_file(temp_dir, item.get("pause_after_ms", 0), silence_cache)
             if pause:
                 parts.append(pause)
-        encode_concat(parts, audio_path, profile)
+        peak_guard = encode_concat(parts, audio_path, profile)
 
     engine_code_sha = sha256_file(Path(__file__))
     fingerprint_payload = {
@@ -74,6 +74,7 @@ def assemble_plan(plan_path, output_root):
         "assembly": {
             "input_count": len(input_evidence),
             "inputs": input_evidence,
+            "encoding_peak_guard": peak_guard,
         },
         "warnings": [],
     }

--- a/src/audio_engine/audio.py
+++ b/src/audio_engine/audio.py
@@ -35,28 +35,77 @@ def silence_file(directory, duration_ms, cache):
     cache[duration_ms] = path
     return path
 
+def measure_encoded_true_peak_dbtp(path):
+    completed = subprocess.run(
+        [
+            ffmpeg_exe(),
+            "-hide_banner",
+            "-nostats",
+            "-i",
+            str(path),
+            "-af",
+            "loudnorm=I=-16:TP=-2.5:LRA=11:print_format=json",
+            "-f",
+            "null",
+            "-",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or "true-peak analysis failed")
+    values = re.findall(r'"input_tp"\s*:\s*"([^"]+)"', completed.stderr)
+    if not values:
+        raise RuntimeError("Could not parse encoded true peak")
+    return float(values[-1])
+
+
 def encode_concat(parts, output_path, profile):
     concat_file = Path(output_path).with_suffix(".concat.txt")
     concat_file.write_text(
         "".join(f"file '{Path(part).resolve()}'\n" for part in parts),
         encoding="utf-8",
     )
-    filter_value = (
-        f"loudnorm=I={profile['loudness_lufs']}:"
-        f"TP={profile['true_peak_db']}:LRA={profile['lra']}"
-    )
+    requested_peak = float(profile["true_peak_db"])
+    filter_peak = requested_peak
+    measured_peak = None
+    attempts = 0
     try:
-        run_ffmpeg([
-            "-f", "concat", "-safe", "0", "-i", str(concat_file),
-            "-af", filter_value,
-            "-c:a", profile["codec"],
-            "-b:a", f"{profile['bitrate_kbps']}k",
-            "-ar", str(profile["sample_rate_hz"]),
-            "-ac", str(profile["channels"]),
-            str(output_path),
-        ])
+        for attempts in range(1, 4):
+            filter_value = (
+                f"loudnorm=I={profile['loudness_lufs']}:"
+                f"TP={filter_peak:.3f}:LRA={profile['lra']}"
+            )
+            run_ffmpeg([
+                "-f", "concat", "-safe", "0", "-i", str(concat_file),
+                "-af", filter_value,
+                "-c:a", profile["codec"],
+                "-b:a", f"{profile['bitrate_kbps']}k",
+                "-ar", str(profile["sample_rate_hz"]),
+                "-ac", str(profile["channels"]),
+                str(output_path),
+            ])
+            measured_peak = measure_encoded_true_peak_dbtp(output_path)
+            if measured_peak <= requested_peak + 0.5:
+                break
+            excess = measured_peak - requested_peak
+            filter_peak -= excess + 0.5
+        else:
+            raise RuntimeError(
+                "Encoded true peak remains above bounded assembly target after "
+                f"3 attempts: {measured_peak:.3f} dBTP > {requested_peak + 0.5:.3f} dBTP"
+            )
     finally:
         concat_file.unlink(missing_ok=True)
+
+    return {
+        "requested_true_peak_dbtp": requested_peak,
+        "effective_loudnorm_true_peak_dbtp": round(filter_peak, 3),
+        "measured_encoded_true_peak_dbtp": round(float(measured_peak), 3),
+        "attempts": attempts,
+        "acceptance_ceiling_dbtp": round(requested_peak + 0.5, 3),
+    }
 
 def probe_duration_seconds(path):
     result = subprocess.run(

--- a/tests/test_assembly_peak_guard.py
+++ b/tests/test_assembly_peak_guard.py
@@ -1,0 +1,63 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from audio_engine.audio import encode_concat
+
+
+PROFILE = {
+    "loudness_lufs": -16,
+    "true_peak_db": -2.5,
+    "lra": 11,
+    "codec": "libmp3lame",
+    "bitrate_kbps": 80,
+    "sample_rate_hz": 24000,
+    "channels": 1,
+}
+
+
+class AssemblyPeakGuardTests(unittest.TestCase):
+    def test_reencodes_from_source_with_stricter_peak_after_mp3_overshoot(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out = root / "block.mp3"
+            with (
+                patch("audio_engine.audio.run_ffmpeg") as render,
+                patch(
+                    "audio_engine.audio.measure_encoded_true_peak_dbtp",
+                    side_effect=[0.31, -2.4],
+                ),
+            ):
+                report = encode_concat(
+                    [root / "scene-a.mp3", root / "scene-b.mp3"],
+                    out,
+                    PROFILE,
+                )
+
+            self.assertEqual(render.call_count, 2)
+            first = render.call_args_list[0].args[0]
+            second = render.call_args_list[1].args[0]
+            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", first)
+            self.assertIn("loudnorm=I=-16:TP=-5.810:LRA=11", second)
+            self.assertEqual(report["attempts"], 2)
+            self.assertEqual(report["measured_encoded_true_peak_dbtp"], -2.4)
+            self.assertEqual(report["effective_loudnorm_true_peak_dbtp"], -5.81)
+
+    def test_fails_closed_after_bounded_peak_guard_attempts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with (
+                patch("audio_engine.audio.run_ffmpeg") as render,
+                patch(
+                    "audio_engine.audio.measure_encoded_true_peak_dbtp",
+                    side_effect=[0.0, 0.0, 0.0],
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "after 3 attempts"):
+                    encode_concat([root / "scene.mp3"], root / "block.mp3", PROFILE)
+            self.assertEqual(render.call_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the generic fan-in defect exposed by Odyssée Block B.

Observed evidence on Production run 33525198119:
- all Block B scene shards ready, including S08;
- assembly succeeded;
- duration/hash/input/silence QA passed;
- encoded MP3 true peak was +0.31 dBTP vs profile target -2.5 dBTP;
- block therefore correctly failed clipping/levels QA.

The defect is post-loudnorm lossy encoding overshoot at assembly level.

This patch:
- measures true peak on the encoded assembly;
- if it exceeds target + 0.5 dB, re-encodes from the original qualified inputs with a stricter loudnorm TP target;
- performs at most 3 total attempts;
- fails closed if the encoded ceiling still cannot be met;
- records requested/effective/measured peak and attempt count in assembly provenance;
- adds regression tests for bounded correction and hard failure.

Scene rendering, provider synthesis, P5 recipe and product logic are unchanged.