### PR TITLE
prod: separate casting identity from explicit performance provider

### DIFF
--- a/docs/PRODUCTION_WORKFLOW.md
+++ b/docs/PRODUCTION_WORKFLOW.md
@@ -60,3 +60,24 @@ Cache entries are not evidence.
 ## Release
 
 `publish_release: true` requires an explicit `release_tag`. Release publication is gated on a `ready` master result. A HOLD or failed unit can therefore never be silently published as a final master.
+
+
+## Explicit performance providers
+
+A character's casting identity and the provider used to perform a particular
+segment are separate contracts.
+
+Use `performance_provider` only when the product has explicitly qualified a
+cross-provider performance path that preserves an already-frozen identity, for
+example a local model conditioned on the frozen reference voice.
+
+The base `provider` / preset still defines casting identity. The resolver:
+
+- keeps one stable `casting_identity` per `character_id`;
+- routes synthesis through `performance_provider` only on the declared segment;
+- fingerprints both casting identity and performance-provider controls;
+- still rejects any silent change of the base provider/voice identity;
+- never falls back when the performance provider is unavailable.
+
+This is not a recasting mechanism. It is an explicit, provenance-bound
+performance implementation of an already-qualified identity.

--- a/src/audio_engine/contract.py
+++ b/src/audio_engine/contract.py
@@ -309,6 +309,8 @@ def validate_program(program):
                 errors.append(f"segments[{index}] needs voice, preset, or target")
             if "provider" in segment and not _non_empty_string(segment.get("provider")):
                 errors.append(f"segments[{index}].provider must be a non-empty string")
+            if "performance_provider" in segment and not _non_empty_string(segment.get("performance_provider")):
+                errors.append(f"segments[{index}].performance_provider must be a non-empty string")
             if "provider_parameters" in segment and not isinstance(segment.get("provider_parameters"), dict):
                 errors.append(f"segments[{index}].provider_parameters must be an object")
             if "provider_seed" in segment:

--- a/src/audio_engine/voice/render.py
+++ b/src/audio_engine/voice/render.py
@@ -43,10 +43,10 @@ def voice_content_key(segment, provider_name):
         "volume": segment.get("volume", "+0%"),
         "provider_parameters": segment.get("provider_parameters"),
         "provider_seed": segment.get("provider_seed"),
-        "casting_identity": segment.get("casting_identity"),
-        "identity_provider": segment.get("identity_provider"),
-        "performance_provider": segment.get("performance_provider"),
     }
+    if segment.get("performance_provider"):
+        payload["casting_identity"] = segment.get("casting_identity")
+        payload["performance_provider"] = segment.get("performance_provider")
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
@@ -71,10 +71,10 @@ def voice_fingerprint(segment, provider):
         "volume": segment.get("volume", "+0%"),
         "provider_parameters": segment.get("provider_parameters"),
         "provider_seed": segment.get("provider_seed"),
-        "casting_identity": segment.get("casting_identity"),
-        "identity_provider": segment.get("identity_provider"),
-        "performance_provider": segment.get("performance_provider"),
     }
+    if segment.get("performance_provider"):
+        payload["casting_identity"] = segment.get("casting_identity")
+        payload["performance_provider"] = segment.get("performance_provider")
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()

--- a/src/audio_engine/voice/render.py
+++ b/src/audio_engine/voice/render.py
@@ -43,6 +43,9 @@ def voice_content_key(segment, provider_name):
         "volume": segment.get("volume", "+0%"),
         "provider_parameters": segment.get("provider_parameters"),
         "provider_seed": segment.get("provider_seed"),
+        "casting_identity": segment.get("casting_identity"),
+        "identity_provider": segment.get("identity_provider"),
+        "performance_provider": segment.get("performance_provider"),
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
@@ -68,6 +71,9 @@ def voice_fingerprint(segment, provider):
         "volume": segment.get("volume", "+0%"),
         "provider_parameters": segment.get("provider_parameters"),
         "provider_seed": segment.get("provider_seed"),
+        "casting_identity": segment.get("casting_identity"),
+        "identity_provider": segment.get("identity_provider"),
+        "performance_provider": segment.get("performance_provider"),
     }
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/src/audio_engine/voices.py
+++ b/src/audio_engine/voices.py
@@ -164,13 +164,14 @@ def resolve_segments(program, voice_config):
     for index, segment in enumerate(program["segments"], start=1):
         explicit_voice = segment.get("voice")
         explicit_provider = segment.get("provider")
+        performance_provider = segment.get("performance_provider")
         preset_id = segment.get("preset")
         explicit_character_id = segment.get("character_id")
         character_id = explicit_character_id or f"segment-{index}"
         alternatives = []
 
         if explicit_voice:
-            provider = explicit_provider or "edge"
+            identity_provider = explicit_provider or "edge"
             voice = explicit_voice
             rate = segment.get("rate", "+0%")
             pitch = segment.get("pitch", "+0Hz")
@@ -180,11 +181,11 @@ def resolve_segments(program, voice_config):
             if preset_id not in by_id:
                 raise ValueError(f"Unknown voice preset: {preset_id}")
             preset = by_id[preset_id]
-            provider = preset.get("provider", "edge")
-            if explicit_provider and explicit_provider != provider:
+            identity_provider = preset.get("provider", "edge")
+            if explicit_provider and explicit_provider != identity_provider:
                 raise ValueError(
                     f"Segment provider {explicit_provider!r} conflicts with preset "
-                    f"{preset_id!r} provider {provider!r}"
+                    f"{preset_id!r} provider {identity_provider!r}"
                 )
             voice = preset["voice"]
             rate = segment.get("rate", preset.get("rate", "+0%"))
@@ -193,11 +194,11 @@ def resolve_segments(program, voice_config):
             resolved_preset = preset["id"]
         elif explicit_character_id and character_id in character_cast:
             identity = character_cast[character_id]
-            provider = identity["provider"]
-            if explicit_provider and explicit_provider != provider:
+            identity_provider = identity["provider"]
+            if explicit_provider and explicit_provider != identity_provider:
                 raise ValueError(
                     f"Character {character_id!r} cannot silently change provider "
-                    f"from {provider!r} to {explicit_provider!r}"
+                    f"from {identity_provider!r} to {explicit_provider!r}"
                 )
             voice = identity["voice"]
             rate = segment.get("rate", identity["rate"])
@@ -206,11 +207,11 @@ def resolve_segments(program, voice_config):
             resolved_preset = identity["resolved_preset"]
         else:
             preset, ranked = choose_preset(segment.get("target", {}), presets)
-            provider = preset.get("provider", "edge")
-            if explicit_provider and explicit_provider != provider:
+            identity_provider = preset.get("provider", "edge")
+            if explicit_provider and explicit_provider != identity_provider:
                 raise ValueError(
                     f"Segment provider {explicit_provider!r} conflicts with selected preset "
-                    f"{preset['id']!r} provider {provider!r}"
+                    f"{preset['id']!r} provider {identity_provider!r}"
                 )
             voice = preset["voice"]
             rate = segment.get("rate", preset.get("rate", "+0%"))
@@ -224,27 +225,36 @@ def resolve_segments(program, voice_config):
 
         if explicit_character_id:
             previous = character_cast.get(character_id)
-            if previous and (previous["provider"] != provider or previous["voice"] != voice):
+            if previous and (
+                previous["provider"] != identity_provider
+                or previous["voice"] != voice
+            ):
                 raise ValueError(
                     f"Character {character_id!r} cannot silently change provider identity "
-                    f"from {previous['provider']}:{previous['voice']} to {provider}:{voice}; "
-                    "use a distinct age incarnation until an age lineage has been explicitly qualified"
+                    f"from {previous['provider']}:{previous['voice']} "
+                    f"to {identity_provider}:{voice}; "
+                    "use an explicit qualified identity lineage instead"
                 )
             if previous is None:
                 character_cast[character_id] = _identity_from_resolution(
-                    provider, voice, rate, pitch, volume, resolved_preset
+                    identity_provider, voice, rate, pitch, volume, resolved_preset
                 )
 
+        synthesis_provider = performance_provider or identity_provider
         resolved.append({
             **segment,
             "sequence": index,
             "resolved_preset": resolved_preset,
-            "provider": provider,
+            "provider": synthesis_provider,
+            "identity_provider": identity_provider,
+            "performance_provider": performance_provider,
             "voice": voice,
             "rate": rate,
             "pitch": pitch,
             "volume": volume,
-            "casting_identity": f"{provider}:{voice}" if explicit_character_id else None,
+            "casting_identity": (
+                f"{identity_provider}:{voice}" if explicit_character_id else None
+            ),
             "casting_alternatives": alternatives,
         })
     return resolved

--- a/tests/test_multi_provider.py
+++ b/tests/test_multi_provider.py
@@ -116,6 +116,77 @@ class MultiProviderRoutingTests(unittest.TestCase):
             self.assertEqual(alpha.calls, 2)
             self.assertNotEqual(first_fp, second["mix"]["voice_fingerprints"][0])
 
+    def test_performance_provider_can_change_without_recasting_character_identity(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            program = self.write_program(root, {
+                "schema_version": 6,
+                "id": "performance-provider",
+                "title": "Performance provider",
+                "segments": [
+                    {
+                        "character_id": "hero",
+                        "provider": "alpha",
+                        "voice": "voice-a",
+                        "text": "Baseline.",
+                    },
+                    {
+                        "character_id": "hero",
+                        "provider": "alpha",
+                        "performance_provider": "beta",
+                        "voice": "voice-a",
+                        "text": "Expressive.",
+                        "provider_seed": 42,
+                        "provider_parameters": {"temperature": 0.7},
+                    },
+                ],
+            })
+            alpha = ToneProvider("alpha", 440)
+            beta = ToneProvider("beta", 550)
+            manifest = render_program(
+                program,
+                root / "out",
+                providers={"alpha": alpha, "beta": beta},
+            )
+            self.assertEqual(alpha.calls, 1)
+            self.assertEqual(beta.calls, 1)
+            self.assertEqual(manifest["mix"]["voice_providers"], ["alpha", "beta"])
+            transcript = json.loads(
+                (root / "out" / "performance-provider" / "transcript.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            first, second = transcript["segments"]
+            self.assertEqual(first["casting_identity"], "alpha:voice-a")
+            self.assertEqual(second["casting_identity"], "alpha:voice-a")
+            self.assertEqual(second["identity_provider"], "alpha")
+            self.assertEqual(second["provider"], "beta")
+            self.assertEqual(second["performance_provider"], "beta")
+
+    def test_performance_provider_does_not_authorize_identity_provider_change(self):
+        program = {
+            "schema_version": 6,
+            "id": "continuity-performance",
+            "title": "Continuity performance",
+            "segments": [
+                {
+                    "character_id": "hero",
+                    "provider": "alpha",
+                    "voice": "voice-a",
+                    "text": "Première ligne.",
+                },
+                {
+                    "character_id": "hero",
+                    "provider": "beta",
+                    "performance_provider": "gamma",
+                    "voice": "voice-a",
+                    "text": "Deuxième ligne.",
+                },
+            ],
+        }
+        with self.assertRaisesRegex(ValueError, "cannot silently change provider identity"):
+            resolve_segments(program, {"presets": []})
+
     def test_character_provider_identity_cannot_change_silently(self):
         program = {
             "schema_version": 1,


### PR DESCRIPTION
Adds a generic, fail-closed distinction between casting identity and synthesis/performance provider.

Motivation:
- some already-qualified performances preserve a frozen character identity while using an explicitly qualified local provider conditioned on that identity;
- the current resolver correctly forbids silent provider recasts, but therefore cannot express that approved case.

Contract:
- base preset/voice + provider continue to define casting identity;
- new performance_provider optionally selects the synthesis provider for that exact segment;
- casting_identity remains stable per character_id;
- changing base provider/voice still fails;
- provider parameters and seed remain explicit;
- voice/cache fingerprints bind the performance-provider path;
- ordinary historical cache keys remain unchanged when no performance_provider is used;
- no fallback or discovery is introduced.

Tests prove:
- one character can use an explicitly declared performance provider without changing casting identity;
- performance_provider cannot authorize a hidden identity-provider change;
- existing cache migration remains intact.

No Odyssée/Pénélope/Ulysse-specific logic is added to the engine.