### PR TITLE
prod: diagnose removed Edge voices explicitly

### DIFF
--- a/src/audio_engine/providers/edge.py
+++ b/src/audio_engine/providers/edge.py
@@ -92,6 +92,20 @@ class EdgeProvider:
                 last_error = exc
                 if attempt == 0:
                     await asyncio.sleep(1.5)
+        if isinstance(last_error, edge_tts.exceptions.NoAudioReceived):
+            try:
+                voices = await edge_tts.list_voices()
+                available = {
+                    item.get("ShortName") or item.get("Name")
+                    for item in voices
+                }
+            except Exception:
+                available = None
+            if available is not None and segment["voice"] not in available:
+                raise RuntimeError(
+                    f"Edge voice is unavailable in the current provider catalog: "
+                    f"{segment['voice']!r}. No fallback is allowed."
+                ) from last_error
         raise last_error
 
     def synthesize(self, segment, path):

--- a/tests/test_edge_locale.py
+++ b/tests/test_edge_locale.py
@@ -20,6 +20,47 @@ class EdgeLocaleTests(unittest.TestCase):
         )
         self.assertEqual(_speech_locale(communicate), "fr-FR")
 
+    def test_unavailable_voice_is_reported_explicitly_after_provider_retries(self):
+        class FakeNoAudioReceived(Exception):
+            pass
+
+        class FakeCommunicate:
+            def __init__(self, text, voice, rate, pitch, volume):
+                self.voice = voice
+
+            async def save(self, path):
+                raise FakeNoAudioReceived("no audio")
+
+        async def fake_list_voices():
+            return [
+                {"ShortName": "fr-FR-HenriNeural", "Locale": "fr-FR"},
+                {"ShortName": "fr-FR-DeniseNeural", "Locale": "fr-FR"},
+            ]
+
+        with tempfile.TemporaryDirectory() as temp_value:
+            output = Path(temp_value) / "voice.mp3"
+            with (
+                patch("audio_engine.providers.edge.edge_tts.Communicate", FakeCommunicate),
+                patch(
+                    "audio_engine.providers.edge.edge_tts.exceptions.NoAudioReceived",
+                    FakeNoAudioReceived,
+                ),
+                patch("audio_engine.providers.edge.edge_tts.list_voices", fake_list_voices),
+                patch("audio_engine.providers.edge.asyncio.sleep", return_value=None),
+            ):
+                provider = EdgeProvider()
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Edge voice is unavailable.*fr-FR-AlainNeural.*No fallback",
+                ):
+                    asyncio.run(provider.synthesize_async({
+                        "text": "Bonjour.",
+                        "voice": "fr-FR-AlainNeural",
+                        "rate": "+0%",
+                        "pitch": "+0Hz",
+                        "volume": "+0%",
+                    }, output))
+
     def test_provider_attaches_explicit_language_locale_before_save(self):
         captured = {}
 


### PR DESCRIPTION
Improves fail-closed Production diagnostics for dynamic Edge voice availability.

Observed Odyssée evidence:
- four independent shards using an authorized but removed fr-FR voice all ended in edge_tts.exceptions.NoAudioReceived;
- controls on the same run succeeded;
- a live provider catalog probe confirmed the requested voice is absent.

Behavior after this patch:
- normal synthesis still gets the existing bounded retry;
- only after final NoAudioReceived, the provider queries the current catalog;
- if the requested exact voice is absent, Production raises an explicit "Edge voice is unavailable ... No fallback is allowed" error;
- if catalog diagnosis itself is unavailable, the original provider exception is preserved;
- no provider/voice substitution is performed.

Includes regression coverage. No product-specific logic.