### PR TITLE
prod: restore scene cache safely across engine releases

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -251,14 +251,17 @@ jobs:
               --verify-files --workspace-root . --voice-pack "$VOICE_PACK"
           done
 
-      - name: Restore optional scene cache
+      - name: Restore optional content-addressed scene cache
         uses: actions/cache@v4
         with:
           path: generated/work/${{ matrix.id }}/.cache
           key: >-
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-
-            ${{ needs.plan.outputs.engine_ref }}-${{ matrix.id }}-
-            ${{ matrix.program_sha256 }}-${{ matrix.voice_pack_sha256 }}
+            scene-v2-${{ matrix.id }}-${{ matrix.program_sha256 }}-
+            ${{ matrix.voice_pack_sha256 }}-${{ matrix.provider_packages_fingerprint }}-
+            ${{ needs.plan.outputs.engine_ref }}
+          restore-keys: |
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-
 
       - id: produce
         name: Render and machine-qualify scene shard

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -19,6 +19,16 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         self.assertIn('"state")!="ready"', self.workflow)
         self.assertIn("This is not a final master release.", self.workflow)
 
+    def test_scene_cache_restore_is_cross_engine_but_still_content_addressed(self):
+        self.assertIn("scene-v2-${{ matrix.id }}-${{ matrix.program_sha256 }}", self.workflow)
+        self.assertIn("${{ matrix.provider_packages_fingerprint }}", self.workflow)
+        self.assertIn("${{ needs.plan.outputs.engine_ref }}", self.workflow)
+        self.assertIn("restore-keys: |", self.workflow)
+        self.assertIn(
+            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-",
+            self.workflow,
+        )
+
     def test_production_releases_never_clobber_existing_assets(self):
         self.assertNotIn("gh release upload", self.workflow)
         self.assertNotIn("--clobber", self.workflow)


### PR DESCRIPTION
Improves Production cost/latency without changing correctness or reproducibility.

Current behavior:
- scene cache save/restore key includes exact engine_ref before all scene identity;
- every engine SHA change therefore forces all scene shards to start from an empty cache, even when voice/provider/model/reference fingerprints are unchanged.

This patch:
- keeps a fully specific immutable save key;
- moves scene identity ahead of engine_ref;
- adds a stable restore prefix per scene;
- relies on the engine's existing internal content-addressed voice/ambience/soundscape fingerprints to decide actual reuse;
- unchanged internal fingerprints are reused;
- incompatible entries are simply ignored and regenerated;
- cache remains optional and never participates in correctness/provenance authority.

The exact save key still binds:
- cache namespace;
- runner OS;
- caller repository;
- scene id;
- program SHA;
- voice-pack SHA;
- provider-package fingerprint;
- engine_ref.

Regression coverage enforces this contract.

Closes #221 after merge.