### PR TITLE
prod: migrate legacy scene caches without metadata-only TTS drift

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -276,29 +276,6 @@ jobs:
             exit 2
           fi
 
-      - id: legacy-scene-cache
-        name: Restore optional pre-scene-v2 cache migration source
-        if: inputs.legacy_scene_cache_engine_ref != ''
-        uses: actions/cache/restore@v4
-        with:
-          path: generated/work/${{ matrix.id }}/.cache
-          key: legacy-scene-cache-migration-${{ github.run_id }}-${{ matrix.id }}
-          restore-keys: |
-            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-
-
-      - name: Require opted-in legacy scene cache migration source
-        if: inputs.legacy_scene_cache_engine_ref != ''
-        shell: bash
-        env:
-          MATCHED_KEY: ${{ steps.legacy-scene-cache.outputs.cache-matched-key }}
-          UNIT_ID: ${{ matrix.id }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$MATCHED_KEY" ]]; then
-            echo "ERROR: opted-in legacy scene cache migration source was not found for $UNIT_ID." >&2
-            exit 2
-          fi
-
       - id: scene-cache-v2
         name: Restore optional content-addressed scene cache
         uses: actions/cache@v4
@@ -311,6 +288,29 @@ jobs:
             ${{ needs.plan.outputs.engine_ref }}
           restore-keys: |
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-
+
+      - id: legacy-scene-cache
+        name: Restore optional pre-scene-v2 cache migration source
+        if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: generated/work/${{ matrix.id }}/.cache
+          key: legacy-scene-cache-migration-${{ github.run_id }}-${{ matrix.id }}
+          restore-keys: |
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-
+
+      - name: Require opted-in legacy scene cache migration source
+        if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          MATCHED_KEY: ${{ steps.legacy-scene-cache.outputs.cache-matched-key }}
+          UNIT_ID: ${{ matrix.id }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$MATCHED_KEY" ]]; then
+            echo "ERROR: opted-in legacy scene cache migration source was not found for $UNIT_ID." >&2
+            exit 2
+          fi
 
       - id: produce
         name: Render and machine-qualify scene shard

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: production-v1
         type: string
+      legacy_scene_cache_engine_ref:
+        description: Optional exact pre-scene-v2 engine ref for fail-closed per-unit cache migration
+        required: false
+        default: ''
+        type: string
       max_parallel:
         description: Maximum concurrent scene renders
         required: false
@@ -259,7 +264,8 @@ jobs:
               --verify-files --workspace-root . --voice-pack "$VOICE_PACK"
           done
 
-      - name: Restore optional content-addressed scene cache
+      - id: scene-cache-v2
+        name: Restore optional content-addressed scene cache
         uses: actions/cache@v4
         with:
           path: generated/work/${{ matrix.id }}/.cache
@@ -270,6 +276,33 @@ jobs:
             ${{ needs.plan.outputs.engine_ref }}
           restore-keys: |
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-
+
+      - id: legacy-scene-cache
+        name: Restore optional pre-scene-v2 cache migration source
+        if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: generated/work/${{ matrix.id }}/.cache
+          key: legacy-scene-cache-migration-${{ github.run_id }}-${{ matrix.id }}
+          restore-keys: |
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-
+
+      - name: Require opted-in legacy scene cache migration source
+        if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          LEGACY_ENGINE_REF: ${{ inputs.legacy_scene_cache_engine_ref }}
+          UNIT_ID: ${{ matrix.id }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$LEGACY_ENGINE_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: legacy_scene_cache_engine_ref must be an exact 40-hex commit SHA." >&2
+            exit 2
+          fi
+          if ! find "generated/work/$UNIT_ID/.cache/voices" -type f -name '*.mp3' -print -quit 2>/dev/null | grep -q .; then
+            echo "ERROR: opted-in legacy scene cache migration source was not restored for $UNIT_ID." >&2
+            exit 2
+          fi
 
       - id: produce
         name: Render and machine-qualify scene shard

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -264,6 +264,41 @@ jobs:
               --verify-files --workspace-root . --voice-pack "$VOICE_PACK"
           done
 
+      - name: Validate optional legacy scene cache migration input
+        if: inputs.legacy_scene_cache_engine_ref != ''
+        shell: bash
+        env:
+          LEGACY_ENGINE_REF: ${{ inputs.legacy_scene_cache_engine_ref }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$LEGACY_ENGINE_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: legacy_scene_cache_engine_ref must be an exact 40-hex commit SHA." >&2
+            exit 2
+          fi
+
+      - id: legacy-scene-cache
+        name: Restore optional pre-scene-v2 cache migration source
+        if: inputs.legacy_scene_cache_engine_ref != ''
+        uses: actions/cache/restore@v4
+        with:
+          path: generated/work/${{ matrix.id }}/.cache
+          key: legacy-scene-cache-migration-${{ github.run_id }}-${{ matrix.id }}
+          restore-keys: |
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-
+
+      - name: Require opted-in legacy scene cache migration source
+        if: inputs.legacy_scene_cache_engine_ref != ''
+        shell: bash
+        env:
+          MATCHED_KEY: ${{ steps.legacy-scene-cache.outputs.cache-matched-key }}
+          UNIT_ID: ${{ matrix.id }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$MATCHED_KEY" ]]; then
+            echo "ERROR: opted-in legacy scene cache migration source was not found for $UNIT_ID." >&2
+            exit 2
+          fi
+
       - id: scene-cache-v2
         name: Restore optional content-addressed scene cache
         uses: actions/cache@v4
@@ -276,33 +311,6 @@ jobs:
             ${{ needs.plan.outputs.engine_ref }}
           restore-keys: |
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-
-
-      - id: legacy-scene-cache
-        name: Restore optional pre-scene-v2 cache migration source
-        if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@v4
-        with:
-          path: generated/work/${{ matrix.id }}/.cache
-          key: legacy-scene-cache-migration-${{ github.run_id }}-${{ matrix.id }}
-          restore-keys: |
-            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-
-
-      - name: Require opted-in legacy scene cache migration source
-        if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'
-        shell: bash
-        env:
-          LEGACY_ENGINE_REF: ${{ inputs.legacy_scene_cache_engine_ref }}
-          UNIT_ID: ${{ matrix.id }}
-        run: |
-          set -euo pipefail
-          if [[ ! "$LEGACY_ENGINE_REF" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "ERROR: legacy_scene_cache_engine_ref must be an exact 40-hex commit SHA." >&2
-            exit 2
-          fi
-          if ! find "generated/work/$UNIT_ID/.cache/voices" -type f -name '*.mp3' -print -quit 2>/dev/null | grep -q .; then
-            echo "ERROR: opted-in legacy scene cache migration source was not restored for $UNIT_ID." >&2
-            exit 2
-          fi
 
       - id: produce
         name: Render and machine-qualify scene shard

--- a/src/audio_engine/providers/edge.py
+++ b/src/audio_engine/providers/edge.py
@@ -50,6 +50,21 @@ class EdgeProvider:
     processing = "remote"
     expressive_controls = ("rate", "pitch", "volume")
 
+    # Cache identity is a synthesis contract, not a hash of incidental adapter code.
+    # Bump this value only when successful Edge audio semantics change.
+    cache_identity = (
+        "edge-tts-7.2.8|ssml-locale-v1|"
+        "voice-synthesis-v2-edge-silence-normalized"
+    )
+
+    # Historical identities whose successful synthesis path and normalized clip
+    # bytes are semantically compatible with cache_identity above. These are
+    # opt-in migration aliases only; the current identity remains authoritative.
+    cache_compatible_identities = (
+        "dfc727bb784bcb630165714b90a01266d524a1c4aa3485b6c6d106e7a1f8e6a6",
+        "7c58d0ba7ff7c0bd2b8a14f28a342274407e893f92d1eccdbb0daca90be2b380",
+    )
+
     def __init__(self):
         patch_ssml_locale()
 

--- a/src/audio_engine/voice/render.py
+++ b/src/audio_engine/voice/render.py
@@ -60,10 +60,10 @@ def provider_cache_identity(provider):
     return str(explicit)
 
 
-def voice_fingerprint(segment, provider):
+def _voice_fingerprint_for_cache_identity(segment, provider_name, cache_identity):
     payload = {
-        "provider": provider.name,
-        "provider_cache_identity": provider_cache_identity(provider),
+        "provider": provider_name,
+        "provider_cache_identity": str(cache_identity),
         "text": segment["text"],
         "voice": segment["voice"],
         "rate": segment.get("rate", "+0%"),
@@ -78,6 +78,32 @@ def voice_fingerprint(segment, provider):
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
+
+
+def voice_fingerprint(segment, provider):
+    return _voice_fingerprint_for_cache_identity(
+        segment,
+        provider.name,
+        provider_cache_identity(provider),
+    )
+
+
+def _cache_compatible_voice_fingerprints(segment, provider):
+    identities = getattr(provider, "cache_compatible_identities", ()) or ()
+    if callable(identities):
+        identities = identities()
+    current = provider_cache_identity(provider)
+    seen = {current}
+    result = []
+    for identity in identities:
+        identity = str(identity or "")
+        if not identity or identity in seen:
+            continue
+        seen.add(identity)
+        result.append(
+            _voice_fingerprint_for_cache_identity(segment, provider.name, identity)
+        )
+    return result
 
 
 def _metadata_path(path):
@@ -183,6 +209,15 @@ def render_voice_clip(segment, provider, cache_root, fallback_fingerprints=None)
     if path.exists() and path.stat().st_size > 0:
         _ensure_timing_metadata(segment, provider, fingerprint, path)
         return path, True, fingerprint
+
+    for compatible in _cache_compatible_voice_fingerprints(segment, provider):
+        legacy = cache_root / f"{compatible}.mp3"
+        if legacy.exists() and legacy.stat().st_size > 0:
+            # The provider explicitly declared this historical identity byte-compatible
+            # with the current successful synthesis contract. Preserve exact clip bytes.
+            shutil.copyfile(legacy, path)
+            _ensure_timing_metadata(segment, provider, fingerprint, path)
+            return path, True, fingerprint
 
     for fallback in fallback_fingerprints or ():
         if not fallback or fallback == fingerprint:

--- a/tests/test_edge_locale.py
+++ b/tests/test_edge_locale.py
@@ -6,9 +6,24 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from audio_engine.providers.edge import EdgeProvider, _speech_locale
+from audio_engine.voice.render import provider_cache_identity
 
 
 class EdgeLocaleTests(unittest.TestCase):
+    def test_cache_identity_is_explicit_and_keeps_qualified_legacy_aliases(self):
+        provider = EdgeProvider()
+        self.assertEqual(
+            provider_cache_identity(provider),
+            "edge-tts-7.2.8|ssml-locale-v1|voice-synthesis-v2-edge-silence-normalized",
+        )
+        self.assertEqual(
+            set(provider.cache_compatible_identities),
+            {
+                "dfc727bb784bcb630165714b90a01266d524a1c4aa3485b6c6d106e7a1f8e6a6",
+                "7c58d0ba7ff7c0bd2b8a14f28a342274407e893f92d1eccdbb0daca90be2b380",
+            },
+        )
+
     def test_native_voice_uses_its_provider_locale(self):
         communicate = SimpleNamespace(voice="fr-FR-DeniseNeural")
         self.assertEqual(_speech_locale(communicate), "fr-FR")

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -48,6 +48,11 @@ class ProductionWorkflowContractTests(unittest.TestCase):
             self.workflow,
         )
 
+        self.assertIn(
+            "steps.scene-cache-v2.outputs.cache-hit != 'true'",
+            self.workflow,
+        )
+
     def test_local_provider_runtime_installers_are_explicit(self):
         self.assertIn("install_chatterbox_mtl_v3_h1b.sh", self.workflow)
         self.assertIn("install_voxcpm2_p4_runtime.sh", self.workflow)

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -29,6 +29,25 @@ class ProductionWorkflowContractTests(unittest.TestCase):
             self.workflow,
         )
 
+    def test_legacy_scene_cache_migration_is_explicit_opt_in_and_fail_closed(self):
+        self.assertIn("legacy_scene_cache_engine_ref:", self.workflow)
+        self.assertIn("default: ''", self.workflow)
+        self.assertIn("actions/cache/restore@v4", self.workflow)
+        self.assertIn("cache-matched-key", self.workflow)
+        self.assertIn(
+            "legacy_scene_cache_engine_ref must be an exact 40-hex commit SHA",
+            self.workflow,
+        )
+        self.assertIn(
+            "opted-in legacy scene cache migration source was not found",
+            self.workflow,
+        )
+        self.assertIn(
+            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- "
+            "${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-",
+            self.workflow,
+        )
+
     def test_local_provider_runtime_installers_are_explicit(self):
         self.assertIn("install_chatterbox_mtl_v3_h1b.sh", self.workflow)
         self.assertIn("install_voxcpm2_p4_runtime.sh", self.workflow)

--- a/tests/test_voice_cache_migration.py
+++ b/tests/test_voice_cache_migration.py
@@ -5,6 +5,10 @@ from pathlib import Path
 
 from audio_engine.audio import run_ffmpeg
 from audio_engine.render import render_program
+from audio_engine.voice.render import (
+    _voice_fingerprint_for_cache_identity,
+    render_voice_clip,
+)
 
 
 def write_tone(path, duration=0.7):
@@ -54,6 +58,12 @@ class PaddedFakeProvider(FakeProvider):
     def synthesize(self, segment, path):
         self.calls += 1
         write_padded_tone(path)
+
+
+class CompatibleFakeProvider(FakeProvider):
+    name = "fake-compatible"
+    cache_identity = "current-compatible-v2"
+    cache_compatible_identities = ("legacy-compatible-v1",)
 
 
 class VoiceCacheMigrationTests(unittest.TestCase):
@@ -110,6 +120,67 @@ class VoiceCacheMigrationTests(unittest.TestCase):
             # Provider padding is gone; the deliberate 250 ms internal pause survives.
             self.assertGreater(timing["measured_duration_ms"], 850)
             self.assertLess(timing["measured_duration_ms"], 1300)
+
+    def test_provider_declared_compatible_cache_rekeys_exact_bytes_without_provider_call(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            cache = Path(temp_value) / "voices"
+            cache.mkdir(parents=True)
+            segment = {
+                "voice": "voice-a",
+                "text": "Exact cached sentence.",
+                "rate": "+0%",
+                "pitch": "+0Hz",
+                "volume": "+0%",
+            }
+            provider = CompatibleFakeProvider()
+            legacy_fp = _voice_fingerprint_for_cache_identity(
+                segment,
+                provider.name,
+                "legacy-compatible-v1",
+            )
+            legacy_clip = cache / f"{legacy_fp}.mp3"
+            write_tone(legacy_clip)
+            legacy_bytes = legacy_clip.read_bytes()
+
+            path, cache_hit, current_fp = render_voice_clip(segment, provider, cache)
+
+            self.assertTrue(cache_hit)
+            self.assertEqual(provider.calls, 0)
+            self.assertNotEqual(current_fp, legacy_fp)
+            self.assertEqual(path.read_bytes(), legacy_bytes)
+            self.assertEqual(
+                current_fp,
+                _voice_fingerprint_for_cache_identity(
+                    segment,
+                    provider.name,
+                    provider.cache_identity,
+                ),
+            )
+
+    def test_undeclared_legacy_cache_identity_never_bypasses_provider(self):
+        with tempfile.TemporaryDirectory() as temp_value:
+            cache = Path(temp_value) / "voices"
+            cache.mkdir(parents=True)
+            segment = {
+                "voice": "voice-a",
+                "text": "Must synthesize.",
+                "rate": "+0%",
+                "pitch": "+0Hz",
+                "volume": "+0%",
+            }
+            provider = CompatibleFakeProvider()
+            undeclared_fp = _voice_fingerprint_for_cache_identity(
+                segment,
+                provider.name,
+                "not-approved-for-migration",
+            )
+            write_tone(cache / f"{undeclared_fp}.mp3")
+
+            _, cache_hit, current_fp = render_voice_clip(segment, provider, cache)
+
+            self.assertFalse(cache_hit)
+            self.assertEqual(provider.calls, 1)
+            self.assertNotEqual(current_fp, undeclared_fp)
 
     def test_new_synthesis_normalizes_only_clip_edges(self):
         with tempfile.TemporaryDirectory() as temp_value:


### PR DESCRIPTION
Closes #230.

## Problem

Production already has safe `scene-v2` cross-engine cache restore, but a consumer upgrading from the pre-`scene-v2` workflow cannot reuse its qualified per-unit voice cache. In addition, Edge cache identity was derived from the complete adapter source file, so #223's diagnostics-only change invalidated otherwise identical successful synthesis.

This caused a real long-form regression: Program metadata-only edits forced remote Edge resynthesis and changed final audio bytes even though spoken text, voices and sound assets were unchanged.

## Contract

- add optional `legacy_scene_cache_engine_ref` to the reusable Production workflow;
- migration is disabled by default;
- when explicitly enabled, require an exact 40-hex legacy engine SHA;
- restore the historical per-unit cache key and fail closed if no matching cache exists;
- keep the current fully-specific `scene-v2` save key and restore prefix;
- providers may declare cache-compatible historical identities explicitly;
- undeclared identities are never reused;
- compatible clips are copied byte-for-byte to the current fingerprint without provider synthesis;
- give Edge a stable semantic cache identity tied to its successful synthesis contract;
- declare only the two verified historical Edge identities as migration-compatible.

## Tests

- exact-byte reuse + zero provider calls for an explicitly compatible identity;
- undeclared legacy identity forces provider synthesis;
- workflow migration is opt-in and fail-closed;
- Edge current identity and historical aliases are pinned.

No product-specific Odyssée logic is introduced.