### PR TITLE
prod: add bounded subtle stereo placement without numeric pan

### DIFF
--- a/docs/PRODUCTION_RECIPES.md
+++ b/docs/PRODUCTION_RECIPES.md
@@ -61,7 +61,7 @@ Use this as the default. Do not add stereo or sound design when it does not impr
 }
 ```
 
-Keep a character's placement stable unless the story gives a real reason to move it.
+Keep a character's placement stable unless the story gives a real reason to move it. Prefer `slight-left` / `slight-right` when subtle separation is sufficient; `left` / `right` remain the stronger ±0.45 positions.
 
 ## Recipe 3 — Continuous environment under narration
 
@@ -124,7 +124,7 @@ Prefer `speech` when the environment competes with intelligibility.
 }
 ```
 
-Use explicit `at_ms`. The public placement vocabulary is only `left`, `center`, `right`.
+Use explicit `at_ms`. The public placement vocabulary is bounded and semantic: `left`, `slight-left`, `center`, `slight-right`, `right`. Use `slight-left` / `slight-right` for restrained ±0.16 placement; arbitrary numeric pan remains forbidden.
 
 Choose an intrinsically short one-shot for `punctuation`. This role has no authored play-duration field: the mixer uses the source naturally within the remaining master window. A long source is therefore a poor punctuation ingredient even when it is technically valid as an event asset.
 

--- a/docs/SOUNDS.md
+++ b/docs/SOUNDS.md
@@ -86,7 +86,7 @@ Bounds are intentional:
 - at most two continuous layers;
 - at most sixteen explicit events;
 - event timing is explicit `at_ms`;
-- optional semantic event placement is `left`, `center` or `right`;
+- optional semantic event placement is `left`, `slight-left`, `center`, `slight-right` or `right`; subtle placements are fixed at ±0.16 and arbitrary numeric pan remains forbidden;
 - one global environment ducking mode: `speech` or `off`.
 
 There is no random scheduling. Two renders of the same declared program and assets must produce the same scene structure.

--- a/src/audio_engine/contract.py
+++ b/src/audio_engine/contract.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from .effects import acoustic_space_ids
 
 SUPPORTED_SCHEMA_VERSIONS = (1, 2, 3, 4, 5, 6)
-PLACEMENTS = ("left", "center", "right")
+PLACEMENTS = ("left", "slight-left", "center", "slight-right", "right")
 DUCKING_MODES = ("speech", "off")
 EVENT_ROLES_V4 = ("punctuation", "scene")
 EVENT_ROLES_V5 = ("punctuation", "scene", "bridge")

--- a/src/audio_engine/mix/render.py
+++ b/src/audio_engine/mix/render.py
@@ -6,7 +6,9 @@ from ..effects import acoustic_space_filter
 
 PLACEMENT_PAN = {
     "left": -0.45,
+    "slight-left": -0.16,
     "center": 0.0,
+    "slight-right": 0.16,
     "right": 0.45,
 }
 

--- a/src/audio_engine/sound/render.py
+++ b/src/audio_engine/sound/render.py
@@ -14,7 +14,9 @@ from .catalog import load_catalog, sound_info
 
 PLACEMENT_PAN = {
     "left": -0.45,
+    "slight-left": -0.16,
     "center": 0.0,
+    "slight-right": 0.16,
     "right": 0.45,
 }
 

--- a/tests/test_soundscape_render.py
+++ b/tests/test_soundscape_render.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from audio_engine.audio import run_ffmpeg
 from audio_engine.contract import sha256_file
 from audio_engine.render import render_program
+from audio_engine.sound.render import PLACEMENT_PAN as SOUND_PLACEMENT_PAN
 
 
 class FakeProvider:
@@ -38,6 +39,12 @@ def make_audio(path, source, duration=1.0, channels=2):
 
 
 class SoundscapeRenderTests(unittest.TestCase):
+    def test_subtle_event_pan_values_are_exactly_bounded(self):
+        self.assertEqual(SOUND_PLACEMENT_PAN["slight-left"], -0.16)
+        self.assertEqual(SOUND_PLACEMENT_PAN["slight-right"], 0.16)
+        self.assertEqual(SOUND_PLACEMENT_PAN["left"], -0.45)
+        self.assertEqual(SOUND_PLACEMENT_PAN["right"], 0.45)
+
     def test_local_bed_layer_event_render_and_voice_reuse(self):
         with tempfile.TemporaryDirectory() as temp_value:
             root = Path(temp_value)

--- a/tests/test_v2_contract.py
+++ b/tests/test_v2_contract.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from audio_engine.ambience.prepare import resolve_ambience_source
 from audio_engine.contract import ContractError, validate_program
+from audio_engine.mix.render import _declared_position
 
 
 class V2ContractTests(unittest.TestCase):
@@ -19,6 +20,27 @@ class V2ContractTests(unittest.TestCase):
                         "ambience": {"file": file_value},
                         "segments": [{"voice": "test", "text": "Hello"}],
                     })
+
+    def test_bounded_subtle_semantic_placements_are_public_contract(self):
+        for placement, expected_pan in (("slight-left", -0.16), ("slight-right", 0.16)):
+            with self.subTest(placement=placement):
+                program = validate_program({
+                    "schema_version": 2,
+                    "id": "subtle-placement",
+                    "title": "Subtle placement",
+                    "actors": {"speaker": {"placement": placement}},
+                    "segments": [{
+                        "character_id": "speaker",
+                        "voice": "test",
+                        "text": "Hello",
+                    }],
+                })
+                resolved, pan = _declared_position(
+                    program["segments"][0],
+                    program["actors"],
+                )
+                self.assertEqual(resolved, placement)
+                self.assertEqual(pan, expected_pan)
 
     def test_numeric_pan_is_not_public_contract(self):
         with self.assertRaises(ContractError):

--- a/tests/test_v3_soundscape.py
+++ b/tests/test_v3_soundscape.py
@@ -32,6 +32,15 @@ class V3SoundscapeContractTests(unittest.TestCase):
         with self.assertRaises(ContractError):
             validate_program(data)
 
+    def test_accepts_bounded_subtle_event_placements(self):
+        for placement in ("slight-left", "slight-right"):
+            with self.subTest(placement=placement):
+                data = base_program()
+                data["soundscape"]["events"] = [
+                    {"file": "bell.wav", "at_ms": 1200, "placement": placement}
+                ]
+                self.assertEqual(validate_program(data)["schema_version"], 3)
+
     def test_rejects_more_than_two_layers(self):
         data = base_program()
         data["soundscape"]["layers"].append({"file": "rain.wav"})


### PR DESCRIPTION
Closes #232.

Adds two generic semantic placement values:
- `slight-left` = -0.16
- `slight-right` = +0.16

Existing `left/center/right` values remain unchanged, including ±0.45 for the strong lateral positions. Arbitrary public numeric `pan` remains rejected.

The new bounded values are implemented consistently for spoken actors/segments and sound events through the existing deterministic constant-power mixer.

Regression coverage:
- public contract accepts both subtle values;
- spoken placement resolves to exact ±0.16;
- sound-event map is pinned to exact ±0.16;
- existing strong positions are pinned unchanged;
- existing numeric-pan rejection remains in force.

Documentation is updated without adding any product-specific concept.