### PR TITLE
prod: scope legacy scene-cache migration to exact Program SHA

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -297,7 +297,7 @@ jobs:
           path: generated/work/${{ matrix.id }}/.cache
           key: legacy-scene-cache-migration-${{ github.run_id }}-${{ matrix.id }}
           restore-keys: |
-            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}- ${{ matrix.program_sha256 }}-
 
       - name: Require opted-in legacy scene cache migration source
         if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -44,7 +44,8 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         )
         self.assertIn(
             "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- "
-            "${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-",
+            "${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}- "
+            "${{ matrix.program_sha256 }}-",
             self.workflow,
         )
 


### PR DESCRIPTION
Closes #235.

Narrows the opt-in pre-`scene-v2` cache migration source from a unit-only prefix to:

`<namespace>-<os>-<repo>- <legacy-engine>-<unit>- <program-sha>-`

This prevents GitHub Actions from choosing a newer cache produced for a different Program SHA of the same unit.

The historical voice-pack SHA is intentionally not pinned at the restore layer: voice-pack migrations are legitimate, and internal per-clip fingerprints remain the authority for actual reuse.

This correction is required by a concrete product qualification that restored full cache hits from the wrong Program revision and exactly reproduced previously rejected audio bytes.

No synthesis or artistic behavior changes.