### PR TITLE
prod: promote scene-v3 cache with ready-only safe migration

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -22,6 +22,16 @@ on:
         required: false
         default: ''
         type: string
+      legacy_scene_cache_voice_pack_sha256:
+        description: Optional exact historical voice-pack SHA-256 to narrow pre-scene-v2 migration
+        required: false
+        default: ''
+        type: string
+      legacy_scene_cache_force_units_json:
+        description: JSON array of unit ids that must bypass scene-v2 and migrate from the explicit legacy source
+        required: false
+        default: '[]'
+        type: string
       max_parallel:
         description: Maximum concurrent scene renders
         required: false
@@ -264,34 +274,105 @@ jobs:
               --verify-files --workspace-root . --voice-pack "$VOICE_PACK"
           done
 
-      - name: Validate optional legacy scene cache migration input
-        if: inputs.legacy_scene_cache_engine_ref != ''
+      - id: cache-migration-policy
+        name: Resolve scene-v3 cache migration policy
         shell: bash
         env:
+          UNIT_ID: ${{ matrix.id }}
           LEGACY_ENGINE_REF: ${{ inputs.legacy_scene_cache_engine_ref }}
+          LEGACY_VOICE_PACK_SHA: ${{ inputs.legacy_scene_cache_voice_pack_sha256 }}
+          FORCE_UNITS_JSON: ${{ inputs.legacy_scene_cache_force_units_json }}
         run: |
           set -euo pipefail
-          if [[ ! "$LEGACY_ENGINE_REF" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "ERROR: legacy_scene_cache_engine_ref must be an exact 40-hex commit SHA." >&2
-            exit 2
-          fi
+          python - <<'PY'
+          import json, os, re
+          from pathlib import Path
 
-      - id: scene-cache-v2
-        name: Restore optional content-addressed scene cache
-        uses: actions/cache@v4
+          unit = os.environ["UNIT_ID"]
+          engine = os.environ["LEGACY_ENGINE_REF"]
+          voice_pack = os.environ["LEGACY_VOICE_PACK_SHA"]
+          try:
+              force_units = json.loads(os.environ["FORCE_UNITS_JSON"])
+          except json.JSONDecodeError as exc:
+              raise SystemExit(f"legacy_scene_cache_force_units_json must be valid JSON: {exc}")
+          if not isinstance(force_units, list) or any(
+              not isinstance(item, str) or not item.strip() for item in force_units
+          ):
+              raise SystemExit("legacy_scene_cache_force_units_json must be a JSON array of non-empty strings")
+          if len(force_units) != len(set(force_units)):
+              raise SystemExit("legacy_scene_cache_force_units_json must not contain duplicates")
+          if engine and not re.fullmatch(r"[0-9a-f]{40}", engine):
+              raise SystemExit("legacy_scene_cache_engine_ref must be an exact 40-hex commit SHA")
+          if voice_pack and not re.fullmatch(r"[0-9a-f]{64}", voice_pack):
+              raise SystemExit("legacy_scene_cache_voice_pack_sha256 must be an exact 64-hex SHA-256")
+          force = unit in force_units
+          if force and not engine:
+              raise SystemExit(
+                  f"{unit}: forced legacy cache migration requires legacy_scene_cache_engine_ref"
+              )
+          if force and not voice_pack:
+              raise SystemExit(
+                  f"{unit}: forced legacy cache migration requires legacy_scene_cache_voice_pack_sha256"
+              )
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as handle:
+              handle.write(f"force_legacy={'true' if force else 'false'}\n")
+          PY
+
+      - id: scene-cache-v3
+        name: Restore optional content-addressed scene-v3 cache
+        if: steps.cache-migration-policy.outputs.force_legacy != 'true'
+        uses: actions/cache/restore@v4
         with:
           path: generated/work/${{ matrix.id }}/.cache
           key: >-
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-
-            scene-v2-${{ matrix.id }}-${{ matrix.program_sha256 }}-
+            scene-v3-${{ matrix.id }}-${{ matrix.program_sha256 }}-
             ${{ matrix.voice_pack_sha256 }}-${{ matrix.provider_packages_fingerprint }}-
             ${{ needs.plan.outputs.engine_ref }}
           restore-keys: |
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v3-${{ matrix.id }}-
+
+      - id: scene-cache-v2-migration
+        name: Restore optional scene-v2 migration source
+        if: >-
+          steps.cache-migration-policy.outputs.force_legacy != 'true' &&
+          steps.scene-cache-v3.outputs.cache-matched-key == ''
+        uses: actions/cache/restore@v4
+        with:
+          path: generated/work/${{ matrix.id }}/.cache
+          key: scene-v2-migration-${{ github.run_id }}-${{ matrix.id }}
+          restore-keys: |
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-
+
+      - id: legacy-scene-cache-exact
+        name: Restore exact pre-scene-v2 cache migration source
+        if: >-
+          inputs.legacy_scene_cache_engine_ref != '' &&
+          inputs.legacy_scene_cache_voice_pack_sha256 != '' &&
+          (
+            steps.cache-migration-policy.outputs.force_legacy == 'true' ||
+            (
+              steps.scene-cache-v3.outputs.cache-matched-key == '' &&
+              steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
+            )
+          )
+        uses: actions/cache/restore@v4
+        with:
+          path: generated/work/${{ matrix.id }}/.cache
+          key: >-
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-
+            ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}-
+            ${{ matrix.program_sha256 }}-${{ inputs.legacy_scene_cache_voice_pack_sha256 }}
 
       - id: legacy-scene-cache
         name: Restore optional pre-scene-v2 cache migration source
-        if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'
+        if: >-
+          inputs.legacy_scene_cache_engine_ref != '' &&
+          inputs.legacy_scene_cache_voice_pack_sha256 == '' &&
+          steps.cache-migration-policy.outputs.force_legacy != 'true' &&
+          steps.scene-cache-v3.outputs.cache-matched-key == '' &&
+          steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
         uses: actions/cache/restore@v4
         with:
           path: generated/work/${{ matrix.id }}/.cache
@@ -300,14 +381,23 @@ jobs:
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}- ${{ matrix.program_sha256 }}-
 
       - name: Require opted-in legacy scene cache migration source
-        if: inputs.legacy_scene_cache_engine_ref != '' && steps.scene-cache-v2.outputs.cache-hit != 'true'
+        if: >-
+          inputs.legacy_scene_cache_engine_ref != '' &&
+          (
+            steps.cache-migration-policy.outputs.force_legacy == 'true' ||
+            (
+              steps.scene-cache-v3.outputs.cache-matched-key == '' &&
+              steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
+            )
+          )
         shell: bash
         env:
-          MATCHED_KEY: ${{ steps.legacy-scene-cache.outputs.cache-matched-key }}
+          EXACT_MATCHED_KEY: ${{ steps.legacy-scene-cache-exact.outputs.cache-matched-key }}
+          PREFIX_MATCHED_KEY: ${{ steps.legacy-scene-cache.outputs.cache-matched-key }}
           UNIT_ID: ${{ matrix.id }}
         run: |
           set -euo pipefail
-          if [[ -z "$MATCHED_KEY" ]]; then
+          if [[ -z "$EXACT_MATCHED_KEY" && -z "$PREFIX_MATCHED_KEY" ]]; then
             echo "ERROR: opted-in legacy scene cache migration source was not found for $UNIT_ID." >&2
             exit 2
           fi
@@ -477,6 +567,43 @@ jobs:
           )
           PY
           fi
+
+      - id: scene-cache-save-gate
+        name: Authorize ready-only scene-v3 cache save
+        if: always()
+        shell: bash
+        env:
+          UNIT_ID: ${{ matrix.id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+
+          result_path = Path("generated/unit-artifacts") / os.environ["UNIT_ID"] / "unit-result.json"
+          ready = False
+          if result_path.is_file():
+              result = json.loads(result_path.read_text(encoding="utf-8"))
+              ready = result.get("state") == "ready"
+          cache_root = Path("generated/work") / os.environ["UNIT_ID"] / ".cache"
+          has_cache = cache_root.is_dir() and any(cache_root.rglob("*"))
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"ready={'true' if ready and has_cache else 'false'}\n")
+          PY
+
+      - name: Save ready-only content-addressed scene-v3 cache
+        if: >-
+          always() &&
+          steps.scene-cache-save-gate.outputs.ready == 'true' &&
+          steps.scene-cache-v3.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: generated/work/${{ matrix.id }}/.cache
+          key: >-
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-
+            scene-v3-${{ matrix.id }}-${{ matrix.program_sha256 }}-
+            ${{ matrix.voice_pack_sha256 }}-${{ matrix.provider_packages_fingerprint }}-
+            ${{ needs.plan.outputs.engine_ref }}
 
       - name: Upload scene shard evidence
         if: always()

--- a/docs/PRODUCTION_WORKFLOW.md
+++ b/docs/PRODUCTION_WORKFLOW.md
@@ -57,6 +57,16 @@ Artifacts are split by retry boundary:
 
 Cache entries are not evidence.
 
+## Scene cache lifecycle
+
+Production uses a ready-only `scene-v3` cache. The cache is an acceleration layer; Program, voice-pack, provider-package and engine fingerprints remain the correctness authority.
+
+On a cache miss, the workflow may migrate compatible `scene-v2` content. A caller can also opt into a pre-`scene-v2` legacy source. For recovery from a known historical source, the caller may force selected unit ids and bind that restore to an exact legacy engine commit, Program SHA-256 and historical voice-pack SHA-256.
+
+A scene-v3 cache is saved only when the unit result is `ready`. Failed provider calls, failed QA and partial renders are never persisted as reusable scene-v3 caches.
+
+Forced migration is a recovery mechanism, not a fallback: if the exact requested legacy source does not exist, the shard fails closed.
+
 ## Release
 
 `publish_release: true` requires an explicit `release_tag`. Release publication is gated on a `ready` master result. A HOLD or failed unit can therefore never be silently published as a final master.

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -19,40 +19,48 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         self.assertIn('"state")!="ready"', self.workflow)
         self.assertIn("This is not a final master release.", self.workflow)
 
-    def test_scene_cache_restore_is_cross_engine_but_still_content_addressed(self):
-        self.assertIn("scene-v2-${{ matrix.id }}-${{ matrix.program_sha256 }}", self.workflow)
+    def test_scene_v3_cache_is_content_addressed_and_migrates_v2(self):
+        self.assertIn("scene-v3-${{ matrix.id }}-${{ matrix.program_sha256 }}", self.workflow)
         self.assertIn("${{ matrix.provider_packages_fingerprint }}", self.workflow)
         self.assertIn("${{ needs.plan.outputs.engine_ref }}", self.workflow)
-        self.assertIn("restore-keys: |", self.workflow)
+        self.assertIn("Restore optional scene-v2 migration source", self.workflow)
         self.assertIn(
             "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-",
             self.workflow,
         )
-
-    def test_legacy_scene_cache_migration_is_explicit_opt_in_and_fail_closed(self):
-        self.assertIn("legacy_scene_cache_engine_ref:", self.workflow)
-        self.assertIn("default: ''", self.workflow)
-        self.assertIn("actions/cache/restore@v4", self.workflow)
-        self.assertIn("cache-matched-key", self.workflow)
         self.assertIn(
-            "legacy_scene_cache_engine_ref must be an exact 40-hex commit SHA",
+            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v3-${{ matrix.id }}-",
+            self.workflow,
+        )
+
+    def test_legacy_scene_cache_migration_can_be_forced_and_exactly_scoped(self):
+        self.assertIn("legacy_scene_cache_engine_ref:", self.workflow)
+        self.assertIn("legacy_scene_cache_voice_pack_sha256:", self.workflow)
+        self.assertIn("legacy_scene_cache_force_units_json:", self.workflow)
+        self.assertIn("default: '[]'", self.workflow)
+        self.assertIn("force_legacy=", self.workflow)
+        self.assertIn("forced legacy cache migration requires legacy_scene_cache_engine_ref", self.workflow)
+        self.assertIn("forced legacy cache migration requires legacy_scene_cache_voice_pack_sha256", self.workflow)
+        self.assertIn("legacy_scene_cache_voice_pack_sha256 must be an exact 64-hex SHA-256", self.workflow)
+        self.assertIn("Restore exact pre-scene-v2 cache migration source", self.workflow)
+        self.assertIn(
+            "${{ matrix.program_sha256 }}-${{ inputs.legacy_scene_cache_voice_pack_sha256 }}",
             self.workflow,
         )
         self.assertIn(
             "opted-in legacy scene cache migration source was not found",
             self.workflow,
         )
-        self.assertIn(
-            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- "
-            "${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}- "
-            "${{ matrix.program_sha256 }}-",
-            self.workflow,
-        )
 
-        self.assertIn(
-            "steps.scene-cache-v2.outputs.cache-hit != 'true'",
-            self.workflow,
-        )
+    def test_scene_v3_cache_is_saved_only_for_ready_units(self):
+        self.assertNotIn("uses: actions/cache@v4", self.workflow)
+        self.assertIn("uses: actions/cache/restore@v4", self.workflow)
+        self.assertIn("uses: actions/cache/save@v4", self.workflow)
+        self.assertIn("Authorize ready-only scene-v3 cache save", self.workflow)
+        self.assertIn('result.get("state") == "ready"', self.workflow)
+        self.assertIn("steps.scene-cache-save-gate.outputs.ready == 'true'", self.workflow)
+        self.assertIn("steps.scene-cache-v3.outputs.cache-hit != 'true'", self.workflow)
+
 
     def test_local_provider_runtime_installers_are_explicit(self):
         self.assertIn("install_chatterbox_mtl_v3_h1b.sh", self.workflow)

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -53,8 +53,8 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         )
 
     def test_scene_v3_cache_is_saved_only_for_ready_units(self):
-        self.assertNotIn("uses: actions/cache@v4", self.workflow)
         self.assertIn("uses: actions/cache/restore@v4", self.workflow)
+        self.assertNotIn("- id: scene-cache-v3\n        name: Restore optional content-addressed scene-v3 cache\n        uses: actions/cache@v4", self.workflow)
         self.assertIn("uses: actions/cache/save@v4", self.workflow)
         self.assertIn("Authorize ready-only scene-v3 cache save", self.workflow)
         self.assertIn('result.get("state") == "ready"', self.workflow)


### PR DESCRIPTION
Closes #240.

Promotes a new generic Production scene-cache lifecycle:

- restore `scene-v3` by content-specific key / safe unit prefix;
- on first migration, restore compatible `scene-v2` when no scene-v3 exists;
- allow selected units to force a pre-scene-v2 migration source;
- forced legacy migration requires exact engine commit + Program SHA and may bind an exact historical voice-pack SHA-256;
- save scene-v3 only when the unit result is `ready`;
- failed / partial provider renders are never persisted as scene-v3 caches;
- internal per-clip fingerprints remain the reuse authority;
- no product-specific logic.

This addresses a concrete production defect where a historical failed provider render left a partial cache that later caused unnecessary resynthesis of unchanged remote speech.

New inputs are default-off:
- `legacy_scene_cache_voice_pack_sha256`
- `legacy_scene_cache_force_units_json` (default `[]`)

Regression tests lock the scene-v3 key, scene-v2 migration, exact legacy voice-pack scoping, force semantics, and ready-only save rule.