### PR TITLE
prod: fix scene-v3 migration prefixes and forced recovery isolation

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -317,6 +317,7 @@ jobs:
           output = Path(os.environ["GITHUB_OUTPUT"])
           with output.open("a", encoding="utf-8") as handle:
               handle.write(f"force_legacy={'true' if force else 'false'}\n")
+              handle.write(f"force_mode={'true' if bool(force_units) else 'false'}\n")
           PY
 
       - id: scene-cache-v3
@@ -331,7 +332,7 @@ jobs:
             ${{ matrix.voice_pack_sha256 }}-${{ matrix.provider_packages_fingerprint }}-
             ${{ needs.plan.outputs.engine_ref }}
           restore-keys: |
-            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v3-${{ matrix.id }}-
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- scene-v3-${{ matrix.id }}-
 
       - id: scene-cache-v2-migration
         name: Restore optional scene-v2 migration source
@@ -343,7 +344,7 @@ jobs:
           path: generated/work/${{ matrix.id }}/.cache
           key: scene-v2-migration-${{ github.run_id }}-${{ matrix.id }}
           restore-keys: |
-            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- scene-v2-${{ matrix.id }}-
 
       - id: legacy-scene-cache-exact
         name: Restore exact pre-scene-v2 cache migration source
@@ -353,6 +354,7 @@ jobs:
           (
             steps.cache-migration-policy.outputs.force_legacy == 'true' ||
             (
+              steps.cache-migration-policy.outputs.force_mode != 'true' &&
               steps.scene-cache-v3.outputs.cache-matched-key == '' &&
               steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
             )
@@ -370,6 +372,7 @@ jobs:
         if: >-
           inputs.legacy_scene_cache_engine_ref != '' &&
           inputs.legacy_scene_cache_voice_pack_sha256 == '' &&
+          steps.cache-migration-policy.outputs.force_mode != 'true' &&
           steps.cache-migration-policy.outputs.force_legacy != 'true' &&
           steps.scene-cache-v3.outputs.cache-matched-key == '' &&
           steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
@@ -380,12 +383,26 @@ jobs:
           restore-keys: |
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- ${{ inputs.legacy_scene_cache_engine_ref }}-${{ matrix.id }}- ${{ matrix.program_sha256 }}-
 
+      - name: Require non-forced cache source during forced recovery
+        if: >-
+          steps.cache-migration-policy.outputs.force_mode == 'true' &&
+          steps.cache-migration-policy.outputs.force_legacy != 'true' &&
+          steps.scene-cache-v3.outputs.cache-matched-key == '' &&
+          steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
+        shell: bash
+        env:
+          UNIT_ID: ${{ matrix.id }}
+        run: |
+          echo "ERROR: forced recovery mode forbids remote resynthesis for non-forced unit $UNIT_ID; no scene-v3 or scene-v2 migration source was found." >&2
+          exit 2
+
       - name: Require opted-in legacy scene cache migration source
         if: >-
           inputs.legacy_scene_cache_engine_ref != '' &&
           (
             steps.cache-migration-policy.outputs.force_legacy == 'true' ||
             (
+              steps.cache-migration-policy.outputs.force_mode != 'true' &&
               steps.scene-cache-v3.outputs.cache-matched-key == '' &&
               steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
             )

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -25,11 +25,11 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         self.assertIn("${{ needs.plan.outputs.engine_ref }}", self.workflow)
         self.assertIn("Restore optional scene-v2 migration source", self.workflow)
         self.assertIn(
-            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v2-${{ matrix.id }}-",
+            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- scene-v2-${{ matrix.id }}-",
             self.workflow,
         )
         self.assertIn(
-            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-scene-v3-${{ matrix.id }}-",
+            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- scene-v3-${{ matrix.id }}-",
             self.workflow,
         )
 
@@ -49,6 +49,21 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         )
         self.assertIn(
             "opted-in legacy scene cache migration source was not found",
+            self.workflow,
+        )
+
+    def test_forced_recovery_is_isolated_from_non_forced_units(self):
+        self.assertIn("force_mode=", self.workflow)
+        self.assertIn(
+            "steps.cache-migration-policy.outputs.force_mode != 'true'",
+            self.workflow,
+        )
+        self.assertIn(
+            "Require non-forced cache source during forced recovery",
+            self.workflow,
+        )
+        self.assertIn(
+            "forced recovery mode forbids remote resynthesis for non-forced unit",
             self.workflow,
         )
 


### PR DESCRIPTION
Closes #242.

Corrects two defects proven by Odyssée qualification run 33607841330:

1. Cross-engine scene-v2/v3 restore prefixes now match the actual folded cache-key format, including the literal space after `<repository>-`.
2. When forced legacy recovery is active for selected units:
   - exact legacy recovery is eligible only for forced units;
   - non-forced units must restore scene-v3 or scene-v2;
   - if neither exists, the shard fails closed before rendering;
   - non-forced units cannot silently fall back to the forced historical source.

General legacy fallback remains available when force-unit mode is not active.

Regression tests pin both literal-space prefixes and forced-mode isolation.

No synthesis implementation, provider semantics or product-specific logic changes.