### PR TITLE
prod: quarantine scene-v3 caches with scene-v4

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -275,7 +275,7 @@ jobs:
           done
 
       - id: cache-migration-policy
-        name: Resolve scene-v3 cache migration policy
+        name: Resolve scene-v4 cache migration policy
         shell: bash
         env:
           UNIT_ID: ${{ matrix.id }}
@@ -321,18 +321,18 @@ jobs:
           PY
 
       - id: scene-cache-v3
-        name: Restore optional content-addressed scene-v3 cache
+        name: Restore optional content-addressed scene-v4 cache
         if: steps.cache-migration-policy.outputs.force_legacy != 'true'
         uses: actions/cache/restore@v4
         with:
           path: generated/work/${{ matrix.id }}/.cache
           key: >-
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-
-            scene-v3-${{ matrix.id }}-${{ matrix.program_sha256 }}-
+            scene-v4-${{ matrix.id }}-${{ matrix.program_sha256 }}-
             ${{ matrix.voice_pack_sha256 }}-${{ matrix.provider_packages_fingerprint }}-
             ${{ needs.plan.outputs.engine_ref }}
           restore-keys: |
-            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- scene-v3-${{ matrix.id }}-
+            ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- scene-v4-${{ matrix.id }}-
 
       - id: scene-cache-v2-migration
         name: Restore optional scene-v2 migration source
@@ -393,7 +393,7 @@ jobs:
         env:
           UNIT_ID: ${{ matrix.id }}
         run: |
-          echo "ERROR: forced recovery mode forbids remote resynthesis for non-forced unit $UNIT_ID; no scene-v3 or scene-v2 migration source was found." >&2
+          echo "ERROR: forced recovery mode forbids remote resynthesis for non-forced unit $UNIT_ID; no scene-v4 or scene-v2 migration source was found." >&2
           exit 2
 
       - name: Require opted-in legacy scene cache migration source
@@ -586,7 +586,7 @@ jobs:
           fi
 
       - id: scene-cache-save-gate
-        name: Authorize ready-only scene-v3 cache save
+        name: Authorize ready-only scene-v4 cache save
         if: always()
         shell: bash
         env:
@@ -608,7 +608,7 @@ jobs:
               handle.write(f"ready={'true' if ready and has_cache else 'false'}\n")
           PY
 
-      - name: Save ready-only content-addressed scene-v3 cache
+      - name: Save ready-only content-addressed scene-v4 cache
         if: >-
           always() &&
           steps.scene-cache-save-gate.outputs.ready == 'true' &&
@@ -618,7 +618,7 @@ jobs:
           path: generated/work/${{ matrix.id }}/.cache
           key: >-
             ${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}-
-            scene-v3-${{ matrix.id }}-${{ matrix.program_sha256 }}-
+            scene-v4-${{ matrix.id }}-${{ matrix.program_sha256 }}-
             ${{ matrix.voice_pack_sha256 }}-${{ matrix.provider_packages_fingerprint }}-
             ${{ needs.plan.outputs.engine_ref }}
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -320,7 +320,7 @@ jobs:
               handle.write(f"force_mode={'true' if bool(force_units) else 'false'}\n")
           PY
 
-      - id: scene-cache-v3
+      - id: scene-cache-v4
         name: Restore optional content-addressed scene-v4 cache
         if: steps.cache-migration-policy.outputs.force_legacy != 'true'
         uses: actions/cache/restore@v4
@@ -338,7 +338,7 @@ jobs:
         name: Restore optional scene-v2 migration source
         if: >-
           steps.cache-migration-policy.outputs.force_legacy != 'true' &&
-          steps.scene-cache-v3.outputs.cache-matched-key == ''
+          steps.scene-cache-v4.outputs.cache-matched-key == ''
         uses: actions/cache/restore@v4
         with:
           path: generated/work/${{ matrix.id }}/.cache
@@ -355,7 +355,7 @@ jobs:
             steps.cache-migration-policy.outputs.force_legacy == 'true' ||
             (
               steps.cache-migration-policy.outputs.force_mode != 'true' &&
-              steps.scene-cache-v3.outputs.cache-matched-key == '' &&
+              steps.scene-cache-v4.outputs.cache-matched-key == '' &&
               steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
             )
           )
@@ -374,7 +374,7 @@ jobs:
           inputs.legacy_scene_cache_voice_pack_sha256 == '' &&
           steps.cache-migration-policy.outputs.force_mode != 'true' &&
           steps.cache-migration-policy.outputs.force_legacy != 'true' &&
-          steps.scene-cache-v3.outputs.cache-matched-key == '' &&
+          steps.scene-cache-v4.outputs.cache-matched-key == '' &&
           steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
         uses: actions/cache/restore@v4
         with:
@@ -387,7 +387,7 @@ jobs:
         if: >-
           steps.cache-migration-policy.outputs.force_mode == 'true' &&
           steps.cache-migration-policy.outputs.force_legacy != 'true' &&
-          steps.scene-cache-v3.outputs.cache-matched-key == '' &&
+          steps.scene-cache-v4.outputs.cache-matched-key == '' &&
           steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
         shell: bash
         env:
@@ -403,7 +403,7 @@ jobs:
             steps.cache-migration-policy.outputs.force_legacy == 'true' ||
             (
               steps.cache-migration-policy.outputs.force_mode != 'true' &&
-              steps.scene-cache-v3.outputs.cache-matched-key == '' &&
+              steps.scene-cache-v4.outputs.cache-matched-key == '' &&
               steps.scene-cache-v2-migration.outputs.cache-matched-key == ''
             )
           )
@@ -612,7 +612,7 @@ jobs:
         if: >-
           always() &&
           steps.scene-cache-save-gate.outputs.ready == 'true' &&
-          steps.scene-cache-v3.outputs.cache-hit != 'true'
+          steps.scene-cache-v4.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: generated/work/${{ matrix.id }}/.cache

--- a/docs/PRODUCTION_WORKFLOW.md
+++ b/docs/PRODUCTION_WORKFLOW.md
@@ -59,11 +59,11 @@ Cache entries are not evidence.
 
 ## Scene cache lifecycle
 
-Production uses a ready-only `scene-v3` cache. The cache is an acceleration layer; Program, voice-pack, provider-package and engine fingerprints remain the correctness authority.
+Production uses a ready-only `scene-v4` cache. `scene-v3` is intentionally quarantined and is never a restore or migration source because that generation may contain structurally READY but product-unqualified provenance. The cache is an acceleration layer; Program, voice-pack, provider-package and engine fingerprints remain the correctness authority.
 
 On a cache miss, the workflow may migrate compatible `scene-v2` content. A caller can also opt into a pre-`scene-v2` legacy source. For recovery from a known historical source, the caller may force selected unit ids and bind that restore to an exact legacy engine commit, Program SHA-256 and historical voice-pack SHA-256.
 
-A scene-v3 cache is saved only when the unit result is `ready`. Failed provider calls, failed QA and partial renders are never persisted as reusable scene-v3 caches.
+A scene-v4 cache is saved only when the unit result is `ready`. Failed provider calls, failed QA and partial renders are never persisted as reusable scene-v4 caches.
 
 Forced migration is a recovery mechanism, not a fallback: if the exact requested legacy source does not exist, the shard fails closed.
 

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -69,17 +69,18 @@ class ProductionWorkflowContractTests(unittest.TestCase):
 
     def test_scene_v3_generation_is_quarantined_from_restore_paths(self):
         self.assertNotIn("Restore optional content-addressed scene-v3 cache", self.workflow)
+        self.assertNotIn("scene-cache-v3", self.workflow)
         self.assertNotIn("scene-v3-${{ matrix.id }}-", self.workflow)
         self.assertIn("Restore optional scene-v2 migration source", self.workflow)
 
     def test_scene_v4_cache_is_saved_only_for_ready_units(self):
         self.assertIn("uses: actions/cache/restore@v4", self.workflow)
-        self.assertNotIn("- id: scene-cache-v3\n        name: Restore optional content-addressed scene-v4 cache\n        uses: actions/cache@v4", self.workflow)
+        self.assertNotIn("- id: scene-cache-v4\n        name: Restore optional content-addressed scene-v4 cache\n        uses: actions/cache@v4", self.workflow)
         self.assertIn("uses: actions/cache/save@v4", self.workflow)
         self.assertIn("Authorize ready-only scene-v4 cache save", self.workflow)
         self.assertIn('result.get("state") == "ready"', self.workflow)
         self.assertIn("steps.scene-cache-save-gate.outputs.ready == 'true'", self.workflow)
-        self.assertIn("steps.scene-cache-v3.outputs.cache-hit != 'true'", self.workflow)
+        self.assertIn("steps.scene-cache-v4.outputs.cache-hit != 'true'", self.workflow)
 
 
     def test_local_provider_runtime_installers_are_explicit(self):

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -19,8 +19,8 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         self.assertIn('"state")!="ready"', self.workflow)
         self.assertIn("This is not a final master release.", self.workflow)
 
-    def test_scene_v3_cache_is_content_addressed_and_migrates_v2(self):
-        self.assertIn("scene-v3-${{ matrix.id }}-${{ matrix.program_sha256 }}", self.workflow)
+    def test_scene_v4_cache_is_content_addressed_and_migrates_v2(self):
+        self.assertIn("scene-v4-${{ matrix.id }}-${{ matrix.program_sha256 }}", self.workflow)
         self.assertIn("${{ matrix.provider_packages_fingerprint }}", self.workflow)
         self.assertIn("${{ needs.plan.outputs.engine_ref }}", self.workflow)
         self.assertIn("Restore optional scene-v2 migration source", self.workflow)
@@ -29,7 +29,7 @@ class ProductionWorkflowContractTests(unittest.TestCase):
             self.workflow,
         )
         self.assertIn(
-            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- scene-v3-${{ matrix.id }}-",
+            "${{ inputs.cache_namespace }}-${{ runner.os }}-${{ github.repository }}- scene-v4-${{ matrix.id }}-",
             self.workflow,
         )
 
@@ -67,11 +67,16 @@ class ProductionWorkflowContractTests(unittest.TestCase):
             self.workflow,
         )
 
-    def test_scene_v3_cache_is_saved_only_for_ready_units(self):
+    def test_scene_v3_generation_is_quarantined_from_restore_paths(self):
+        self.assertNotIn("Restore optional content-addressed scene-v3 cache", self.workflow)
+        self.assertNotIn("scene-v3-${{ matrix.id }}-", self.workflow)
+        self.assertIn("Restore optional scene-v2 migration source", self.workflow)
+
+    def test_scene_v4_cache_is_saved_only_for_ready_units(self):
         self.assertIn("uses: actions/cache/restore@v4", self.workflow)
-        self.assertNotIn("- id: scene-cache-v3\n        name: Restore optional content-addressed scene-v3 cache\n        uses: actions/cache@v4", self.workflow)
+        self.assertNotIn("- id: scene-cache-v3\n        name: Restore optional content-addressed scene-v4 cache\n        uses: actions/cache@v4", self.workflow)
         self.assertIn("uses: actions/cache/save@v4", self.workflow)
-        self.assertIn("Authorize ready-only scene-v3 cache save", self.workflow)
+        self.assertIn("Authorize ready-only scene-v4 cache save", self.workflow)
         self.assertIn('result.get("state") == "ready"', self.workflow)
         self.assertIn("steps.scene-cache-save-gate.outputs.ready == 'true'", self.workflow)
         self.assertIn("steps.scene-cache-v3.outputs.cache-hit != 'true'", self.workflow)


### PR DESCRIPTION
Closes #246.

Promotes a fresh Production cache generation after run 33607841330 proved that some scene-v3 entries are structurally READY but product-unqualified.

Contract:
- primary restore/save namespace is now `scene-v4`;
- `scene-v3` is completely quarantined: no key, restore path, migration path or step identity remains;
- first scene-v4 population for normal units migrates only from qualified `scene-v2` using the exact folded-key spacing fixed by #243;
- forced legacy units keep exact engine + Program + historical voice-pack recovery;
- in forced mode, non-forced units must find scene-v4 or scene-v2, otherwise fail closed before rendering;
- scene-v4 is saved only for READY units;
- provider and synthesis semantics are unchanged.

Regression tests explicitly forbid any residual scene-v3 restore/step reference.