### PR TITLE
prod: preserve assembly loudness with peak-only limiter retries

### DIFF
--- a/src/audio_engine/audio.py
+++ b/src/audio_engine/audio.py
@@ -1,3 +1,4 @@
+import math
 import re
 import subprocess
 from pathlib import Path
@@ -68,15 +69,26 @@ def encode_concat(parts, output_path, profile):
         encoding="utf-8",
     )
     requested_peak = float(profile["true_peak_db"])
-    filter_peak = requested_peak
+    limiter_ceiling_dbfs = None
     measured_peak = None
     attempts = 0
     try:
         for attempts in range(1, 4):
             filter_value = (
                 f"loudnorm=I={profile['loudness_lufs']}:"
-                f"TP={filter_peak:.3f}:LRA={profile['lra']}"
+                f"TP={requested_peak:.3f}:LRA={profile['lra']}"
             )
+            if limiter_ceiling_dbfs is not None:
+                limiter_linear = math.pow(10.0, limiter_ceiling_dbfs / 20.0)
+                if not 0.0625 <= limiter_linear <= 1.0:
+                    raise RuntimeError(
+                        "Required assembly limiter ceiling exceeds bounded alimiter range: "
+                        f"{limiter_ceiling_dbfs:.3f} dBFS"
+                    )
+                filter_value += (
+                    f",alimiter=limit={limiter_linear:.6f}:"
+                    "attack=5:release=50:level=false"
+                )
             run_ffmpeg([
                 "-f", "concat", "-safe", "0", "-i", str(concat_file),
                 "-af", filter_value,
@@ -90,7 +102,10 @@ def encode_concat(parts, output_path, profile):
             if measured_peak <= requested_peak + 0.5:
                 break
             excess = measured_peak - requested_peak
-            filter_peak -= excess + 0.5
+            if limiter_ceiling_dbfs is None:
+                limiter_ceiling_dbfs = requested_peak - excess - 0.5
+            else:
+                limiter_ceiling_dbfs -= excess + 0.5
         else:
             raise RuntimeError(
                 "Encoded true peak remains above bounded assembly target after "
@@ -101,7 +116,12 @@ def encode_concat(parts, output_path, profile):
 
     return {
         "requested_true_peak_dbtp": requested_peak,
-        "effective_loudnorm_true_peak_dbtp": round(filter_peak, 3),
+        "effective_loudnorm_true_peak_dbtp": requested_peak,
+        "effective_limiter_ceiling_dbfs": (
+            round(limiter_ceiling_dbfs, 3)
+            if limiter_ceiling_dbfs is not None
+            else None
+        ),
         "measured_encoded_true_peak_dbtp": round(float(measured_peak), 3),
         "attempts": attempts,
         "acceptance_ceiling_dbtp": round(requested_peak + 0.5, 3),

--- a/tests/test_assembly_peak_guard.py
+++ b/tests/test_assembly_peak_guard.py
@@ -18,7 +18,7 @@ PROFILE = {
 
 
 class AssemblyPeakGuardTests(unittest.TestCase):
-    def test_reencodes_from_source_with_stricter_peak_after_mp3_overshoot(self):
+    def test_reencodes_from_source_with_peak_limiter_without_lowering_loudnorm_target(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             out = root / "block.mp3"
@@ -39,10 +39,33 @@ class AssemblyPeakGuardTests(unittest.TestCase):
             first = render.call_args_list[0].args[0]
             second = render.call_args_list[1].args[0]
             self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", first)
-            self.assertIn("loudnorm=I=-16:TP=-5.810:LRA=11", second)
+            self.assertNotIn("alimiter=", first)
+            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", second)
+            self.assertIn("alimiter=limit=", second)
+            self.assertIn("attack=5:release=50:level=false", second)
             self.assertEqual(report["attempts"], 2)
             self.assertEqual(report["measured_encoded_true_peak_dbtp"], -2.4)
-            self.assertEqual(report["effective_loudnorm_true_peak_dbtp"], -5.81)
+            self.assertEqual(report["effective_loudnorm_true_peak_dbtp"], -2.5)
+            self.assertEqual(report["effective_limiter_ceiling_dbfs"], -5.81)
+
+    def test_no_overshoot_does_not_enable_limiter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out = root / "block.mp3"
+            with (
+                patch("audio_engine.audio.run_ffmpeg") as render,
+                patch(
+                    "audio_engine.audio.measure_encoded_true_peak_dbtp",
+                    return_value=-2.4,
+                ),
+            ):
+                report = encode_concat([root / "scene.mp3"], out, PROFILE)
+
+            self.assertEqual(render.call_count, 1)
+            args = render.call_args_list[0].args[0]
+            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", args)
+            self.assertNotIn("alimiter=", args)
+            self.assertIsNone(report["effective_limiter_ceiling_dbfs"])
 
     def test_fails_closed_after_bounded_peak_guard_attempts(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_assembly_peak_guard.py
+++ b/tests/test_assembly_peak_guard.py
@@ -38,11 +38,13 @@ class AssemblyPeakGuardTests(unittest.TestCase):
             self.assertEqual(render.call_count, 2)
             first = render.call_args_list[0].args[0]
             second = render.call_args_list[1].args[0]
-            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", first)
-            self.assertNotIn("alimiter=", first)
-            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", second)
-            self.assertIn("alimiter=limit=", second)
-            self.assertIn("attack=5:release=50:level=false", second)
+            first_filter = first[first.index("-af") + 1]
+            second_filter = second[second.index("-af") + 1]
+            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", first_filter)
+            self.assertNotIn("alimiter=", first_filter)
+            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", second_filter)
+            self.assertIn("alimiter=limit=", second_filter)
+            self.assertIn("attack=5:release=50:level=false", second_filter)
             self.assertEqual(report["attempts"], 2)
             self.assertEqual(report["measured_encoded_true_peak_dbtp"], -2.4)
             self.assertEqual(report["effective_loudnorm_true_peak_dbtp"], -2.5)
@@ -63,8 +65,9 @@ class AssemblyPeakGuardTests(unittest.TestCase):
 
             self.assertEqual(render.call_count, 1)
             args = render.call_args_list[0].args[0]
-            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", args)
-            self.assertNotIn("alimiter=", args)
+            filter_value = args[args.index("-af") + 1]
+            self.assertIn("loudnorm=I=-16:TP=-2.500:LRA=11", filter_value)
+            self.assertNotIn("alimiter=", filter_value)
             self.assertIsNone(report["effective_limiter_ceiling_dbfs"])
 
     def test_fails_closed_after_bounded_peak_guard_attempts(self):


### PR DESCRIPTION
Closes #248.

Fixes a generic mastering defect proven by Odyssée Block B.

Before:
- MP3 true-peak overshoot caused the entire loudnorm TP target to be lowered on retry;
- Block B ended safe at -2.41 dBTP but too quiet at -18.48 LUFS, failing the existing ±2 LU QA tolerance.

After:
- loudnorm stays fixed at the profile targets on every attempt (speech: I=-16, TP=-2.5, LRA=11);
- only when encoded MP3 overshoots the bounded ceiling, a post-loudnorm `alimiter` ceiling is introduced and progressively tightened;
- each attempt re-renders from source;
- encoded true peak remains the acceptance authority;
- maximum 3 attempts and fail-closed behavior are unchanged;
- manifest evidence records the effective limiter ceiling;
- QA thresholds are unchanged.

Tests cover no-overshoot, limiter retry without lowering loudnorm, and bounded failure.