### PR TITLE
prod: isolate promoted provider runtimes with cache-only final render

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -200,46 +200,6 @@ jobs:
             ${{ inputs.cache_namespace }}-${{ runner.os }}-provider-models-
             ${{ matrix.provider_packages_fingerprint }}
 
-      - name: Install exact promoted provider runtime
-        if: matrix.provider_package_count != 0
-        shell: bash
-        env:
-          PROVIDER_PACKAGES_JSON: ${{ toJSON(matrix.provider_packages) }}
-        run: |
-          set -euo pipefail
-          mapfile -t packages < <(python - <<'PY'
-          import json, os
-          for item in json.loads(os.environ["PROVIDER_PACKAGES_JSON"]):
-              print(item["package"])
-          PY
-          )
-          installed=()
-          for package in "${packages[@]}"; do
-            provider_id="$(python - "$package" <<'PY'
-          import json, sys
-          print(json.load(open(sys.argv[1], encoding="utf-8"))["provider"]["id"])
-          PY
-            )"
-            case "$provider_id" in
-              chatterbox-multilingual-v3)
-                if [[ " ${installed[*]} " != *" $provider_id "* ]]; then
-                  bash .audio-engine/scripts/install_chatterbox_mtl_v3_h1b.sh
-                  installed+=("$provider_id")
-                fi
-                ;;
-              voxcpm2)
-                if [[ " ${installed[*]} " != *" $provider_id "* ]]; then
-                  bash .audio-engine/scripts/install_voxcpm2_p4_runtime.sh
-                  installed+=("$provider_id")
-                fi
-                ;;
-              *)
-                echo "ERROR: Production provider '$provider_id' has no promoted runtime installer." >&2
-                echo "No fallback is allowed." >&2
-                exit 2
-                ;;
-            esac
-          done
 
       - name: Install exact Audio Engine
         run: python -m pip install --disable-pip-version-check ./.audio-engine
@@ -419,6 +379,58 @@ jobs:
             exit 2
           fi
 
+      - name: Prewarm promoted provider voice caches in isolated runtimes
+        if: matrix.provider_package_count != 0
+        shell: bash
+        env:
+          UNIT_ID: ${{ matrix.id }}
+          PROGRAM: ${{ matrix.program }}
+          VOICE_PACK: ${{ matrix.voice_pack }}
+          PROVIDER_PACKAGES_JSON: ${{ toJSON(matrix.provider_packages) }}
+        run: |
+          set -euo pipefail
+          work="generated/work/$UNIT_ID"
+          cache_root="$work/.cache/voices"
+          report_root="$work/provider-prewarm"
+          mkdir -p "$cache_root" "$report_root" generated/provider-venvs
+
+          mapfile -t packages < <(python - <<'PY'
+          import json, os
+          for item in json.loads(os.environ["PROVIDER_PACKAGES_JSON"]):
+              print(item["package"])
+          PY
+          )
+
+          for package in "${packages[@]}"; do
+            provider_id="$(python - "$package" <<'PY'
+          import json, sys
+          print(json.load(open(sys.argv[1], encoding="utf-8"))["provider"]["id"])
+          PY
+            )"
+            safe_id="${provider_id//[^A-Za-z0-9_.-]/_}"
+            venv="generated/provider-venvs/$safe_id"
+            rm -rf "$venv"
+            python -m venv "$venv"
+            # shellcheck disable=SC1090
+            source "$venv/bin/activate"
+            case "$provider_id" in
+              chatterbox-multilingual-v3)
+                bash .audio-engine/scripts/install_chatterbox_mtl_v3_h1b.sh
+                ;;
+              voxcpm2)
+                bash .audio-engine/scripts/install_voxcpm2_p4_runtime.sh
+                ;;
+              *)
+                echo "ERROR: Production provider '$provider_id' has no promoted runtime installer." >&2
+                echo "No fallback is allowed." >&2
+                exit 2
+                ;;
+            esac
+            python -m pip install --disable-pip-version-check --no-deps ./.audio-engine
+            audio-engine provider-cache prewarm "$PROGRAM"               --voices "$VOICE_PACK"               --provider-package "$package"               --cache-root "$cache_root"               --provider-model-cache generated/provider-models               --workspace-root .               > "$report_root/$safe_id.json"
+            deactivate
+          done
+
       - id: produce
         name: Render and machine-qualify scene shard
         shell: bash
@@ -458,7 +470,13 @@ jobs:
           PY
           )
           for package in "${packages[@]}"; do
+            provider_id="$(python - "$package" <<'PY'
+          import json, sys
+          print(json.load(open(sys.argv[1], encoding="utf-8"))["provider"]["id"])
+          PY
+            )"
             provider_args+=(--provider-package "$package")
+            provider_args+=(--cache-only-promoted-provider "$provider_id")
           done
           audio-engine render "$PROGRAM" --out "$work" --voices "$VOICE_PACK" \
             --workspace-root . --provider-model-cache generated/provider-models \
@@ -471,6 +489,7 @@ jobs:
             set +e
             python - "$render_dir/manifest.json" <<'PY'
           import json, os, sys
+          from pathlib import Path
           m=json.load(open(sys.argv[1], encoding="utf-8"))
           expected={
               "source_sha256": os.environ["PROGRAM_SHA"],
@@ -489,6 +508,32 @@ jobs:
               raise SystemExit(
                   f"providers mismatch: {actual_providers} != {expected_providers}"
               )
+          records={
+              item["name"]: item
+              for item in (m.get("providers") or [])
+              if isinstance(item, dict) and item.get("name")
+          }
+          prewarm_root=Path("generated/work") / os.environ["UNIT_ID"] / "provider-prewarm"
+          if prewarm_root.is_dir():
+              reports=[]
+              for report_path in sorted(prewarm_root.glob("*.json")):
+                  reports.append(json.load(open(report_path, encoding="utf-8")))
+              for report in reports:
+                  provider_id=report.get("provider")
+                  if report.get("status")!="ready":
+                      raise SystemExit(f"provider prewarm did not finish ready: {provider_id}")
+                  record=records.get(provider_id)
+                  if record is None:
+                      raise SystemExit(f"prewarmed provider missing from render manifest: {provider_id}")
+                  if record.get("cache_identity")!=report.get("provider_cache_identity"):
+                      raise SystemExit(
+                          f"provider cache identity mismatch for {provider_id}: "
+                          f"{record.get('cache_identity')} != {report.get('provider_cache_identity')}"
+                      )
+                  if not str(record.get("processing", "")).startswith("cache-only:"):
+                      raise SystemExit(
+                          f"promoted provider {provider_id} was not cache-only in final render"
+                      )
           PY
             bind_rc=$?
             if [[ $bind_rc -eq 0 ]]; then
@@ -517,6 +562,9 @@ jobs:
             for name in audio.mp3 manifest.json transcript.json qa-report.json; do
               [[ -f "$render_dir/$name" ]] && cp "$render_dir/$name" "$publish/$program_id/$name"
             done
+          fi
+          if [[ -d "$work/provider-prewarm" ]]; then
+            cp -R "$work/provider-prewarm" "$publish/provider-prewarm"
           fi
 
           RESULT_STATE="$state" RESULT_REASON="$reason" RESULT_PATH="$publish/unit-result.json" python - <<'PY'

--- a/src/audio_engine/cli.py
+++ b/src/audio_engine/cli.py
@@ -13,6 +13,7 @@ from .effects import load_capabilities, public_capabilities
 from .preflight import preflight_program
 from .preview import preview_program
 from .providers.factory import build_promoted_providers
+from .provider_cache import prewarm_promoted_provider_cache
 from .production import (
     hydrate_production_unit_assets,
     production_plan,
@@ -99,6 +100,12 @@ def build_parser():
         help="Immutable promoted provider package; repeat for multiple local providers",
     )
     render.add_argument("--provider-model-cache", default=".provider-models")
+    render.add_argument(
+        "--cache-only-promoted-provider",
+        action="append",
+        default=[],
+        help="Promoted provider id that must be satisfied from prewarmed cache only; repeat as needed",
+    )
     render.add_argument("--workspace-root", default=".")
 
     preview = sub.add_parser("preview", help="Render one program and extract short windows around its sound events")
@@ -187,6 +194,25 @@ def build_parser():
     )
     provider_package_refs.add_argument("package")
     provider_package_refs.add_argument("--workspace-root", default=".")
+
+    provider_cache = sub.add_parser(
+        "provider-cache",
+        help="Prewarm promoted provider voice caches in an isolated runtime",
+    )
+    provider_cache_sub = provider_cache.add_subparsers(
+        dest="provider_cache_command",
+        required=True,
+    )
+    provider_cache_prewarm = provider_cache_sub.add_parser(
+        "prewarm",
+        help="Render only one promoted provider's Program segments into a shared voice cache",
+    )
+    provider_cache_prewarm.add_argument("program")
+    provider_cache_prewarm.add_argument("--voices", required=True)
+    provider_cache_prewarm.add_argument("--provider-package", required=True)
+    provider_cache_prewarm.add_argument("--cache-root", required=True)
+    provider_cache_prewarm.add_argument("--provider-model-cache", default=".provider-models")
+    provider_cache_prewarm.add_argument("--workspace-root", default=".")
 
     qa = sub.add_parser(
         "qa",
@@ -296,6 +322,7 @@ def main(argv=None):
                 args.provider_package,
                 workspace_root=args.workspace_root,
                 model_cache_root=args.provider_model_cache,
+                cache_only_ids=args.cache_only_promoted_provider,
             )
             result = render_program(
                 args.program,
@@ -342,6 +369,15 @@ def main(argv=None):
                     args.unit,
                     workspace_root=args.workspace_root,
                 )
+        elif args.command == "provider-cache":
+            result = prewarm_promoted_provider_cache(
+                args.program,
+                args.voices,
+                args.provider_package,
+                args.cache_root,
+                workspace_root=args.workspace_root,
+                model_cache_root=args.provider_model_cache,
+            )
         elif args.command == "provider-package":
             if args.provider_package_command == "validate":
                 result = provider_package_report(

--- a/src/audio_engine/provider_cache.py
+++ b/src/audio_engine/provider_cache.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from .contract import ContractError, load_json, validate_program
+from .providers.factory import build_promoted_providers
+from .voice.render import provider_cache_identity, render_voice_clip
+from .voices import load_voice_config, resolve_segments
+
+
+def prewarm_promoted_provider_cache(
+    program_path,
+    voices_path,
+    provider_package_path,
+    cache_root,
+    workspace_root=".",
+    model_cache_root=".provider-models",
+):
+    program_path = Path(program_path)
+    program = validate_program(load_json(program_path))
+    voice_config, _ = load_voice_config(voices_path)
+    resolved = resolve_segments(program, voice_config)
+
+    providers = build_promoted_providers(
+        [provider_package_path],
+        workspace_root=workspace_root,
+        model_cache_root=model_cache_root,
+    )
+    if len(providers) != 1:
+        raise ContractError("provider cache prewarm requires exactly one promoted provider package")
+    provider = next(iter(providers.values()))
+
+    selected = [segment for segment in resolved if segment["provider"] == provider.name]
+    if not selected:
+        raise ContractError(
+            f"provider package {provider.name!r} is not used by Program {program['id']!r}"
+        )
+
+    cache_root = Path(cache_root)
+    hits = 0
+    misses = 0
+    fingerprints = []
+    for segment in selected:
+        _, cache_hit, fingerprint = render_voice_clip(
+            segment,
+            provider,
+            cache_root,
+        )
+        fingerprints.append(fingerprint)
+        if cache_hit:
+            hits += 1
+        else:
+            misses += 1
+
+    return {
+        "schema_version": 1,
+        "status": "ready",
+        "program_id": program["id"],
+        "provider": provider.name,
+        "provider_cache_identity": provider_cache_identity(provider),
+        "segment_count": len(selected),
+        "cache_hits": hits,
+        "cache_misses": misses,
+        "fingerprints": fingerprints,
+    }

--- a/src/audio_engine/providers/factory.py
+++ b/src/audio_engine/providers/factory.py
@@ -6,12 +6,39 @@ from .chatterbox_mtl_v3 import ChatterboxMultilingualV3Provider
 from .voxcpm2 import VoxCPM2Provider
 
 
+class CacheOnlyProvider:
+    """Preserve promoted provider identity while forbidding runtime synthesis."""
+
+    def __init__(self, provider):
+        self._provider = provider
+        self.name = provider.name
+        self.processing = f"cache-only:{getattr(provider, 'processing', 'unknown')}"
+        self.edge_silence_normalization = getattr(
+            provider, "edge_silence_normalization", True
+        )
+        self.cache_compatible_identities = getattr(
+            provider, "cache_compatible_identities", ()
+        )
+
+    def cache_identity(self):
+        explicit = getattr(self._provider, "cache_identity", None)
+        return explicit() if callable(explicit) else explicit
+
+    def synthesize(self, segment, path):
+        raise RuntimeError(
+            f"Promoted provider {self.name!r} is cache-only in final render; "
+            "prewarm the exact provider cache in its isolated runtime first"
+        )
+
+
 def build_promoted_providers(
     package_paths,
     workspace_root=".",
     model_cache_root=".provider-models",
+    cache_only_ids=(),
 ):
     providers = {}
+    cache_only_ids = set(cache_only_ids or ())
     cache_root = Path(model_cache_root).resolve()
     for package_path in package_paths or []:
         package_path = Path(package_path)
@@ -41,5 +68,14 @@ def build_promoted_providers(
             raise ContractError(
                 f"provider package {provider_id!r} has no promoted Production adapter"
             )
+        if provider_id in cache_only_ids:
+            provider = CacheOnlyProvider(provider)
         providers[provider_id] = provider
+
+    unknown = cache_only_ids - set(providers)
+    if unknown:
+        raise ContractError(
+            "cache-only promoted provider ids have no matching package: "
+            + ", ".join(sorted(unknown))
+        )
     return providers

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -83,12 +83,21 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         self.assertIn("steps.scene-cache-v4.outputs.cache-hit != 'true'", self.workflow)
 
 
-    def test_local_provider_runtime_installers_are_explicit(self):
+    def test_local_provider_runtimes_are_isolated_and_final_render_is_cache_only(self):
+        self.assertNotIn("Install exact promoted provider runtime", self.workflow)
+        self.assertIn("Prewarm promoted provider voice caches in isolated runtimes", self.workflow)
+        self.assertIn('python -m venv "$venv"', self.workflow)
+        self.assertIn('source "$venv/bin/activate"', self.workflow)
         self.assertIn("install_chatterbox_mtl_v3_h1b.sh", self.workflow)
         self.assertIn("install_voxcpm2_p4_runtime.sh", self.workflow)
         self.assertIn("requirements/chatterbox-mtl-v3-h1b-runtime.txt", self.workflow)
         self.assertIn("requirements/voxcpm2-p4-runtime.txt", self.workflow)
-        self.assertIn("voxcpm2)", self.workflow)
+        self.assertIn("--no-deps ./.audio-engine", self.workflow)
+        self.assertIn("audio-engine provider-cache prewarm", self.workflow)
+        self.assertIn("--cache-only-promoted-provider", self.workflow)
+        self.assertIn("provider cache identity mismatch", self.workflow)
+        self.assertIn("was not cache-only in final render", self.workflow)
+        self.assertIn('cp -R "$work/provider-prewarm" "$publish/provider-prewarm"', self.workflow)
 
     def test_production_releases_never_clobber_existing_assets(self):
         self.assertNotIn("gh release upload", self.workflow)

--- a/tests/test_provider_cache_isolation.py
+++ b/tests/test_provider_cache_isolation.py
@@ -5,11 +5,33 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from audio_engine.audio import run_ffmpeg
 from audio_engine.provider_cache import prewarm_promoted_provider_cache
 from audio_engine.providers.factory import CacheOnlyProvider
 from audio_engine.render import render_program
 
-from test_multi_provider import ToneProvider
+
+class ToneProvider:
+    processing = "local-test"
+
+    def __init__(self, name, frequency):
+        self.name = name
+        self.frequency = frequency
+        self.calls = 0
+
+    def cache_identity(self):
+        return f"{self.name}-runtime-v1"
+
+    def synthesize(self, segment, path):
+        self.calls += 1
+        run_ffmpeg([
+            "-f", "lavfi",
+            "-i", f"sine=frequency={self.frequency}:sample_rate=24000:duration=0.20",
+            "-ac", "1",
+            "-c:a", "libmp3lame",
+            "-b:a", "64k",
+            str(path),
+        ])
 
 
 class ProviderCacheIsolationTests(unittest.TestCase):

--- a/tests/test_provider_cache_isolation.py
+++ b/tests/test_provider_cache_isolation.py
@@ -1,0 +1,127 @@
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from audio_engine.provider_cache import prewarm_promoted_provider_cache
+from audio_engine.providers.factory import CacheOnlyProvider
+from audio_engine.render import render_program
+
+from test_multi_provider import ToneProvider
+
+
+class ProviderCacheIsolationTests(unittest.TestCase):
+    def write_program_and_voices(self, root):
+        root = Path(root)
+        program = root / "program.json"
+        voices = root / "voices.json"
+        program.write_text(
+            json.dumps({
+                "schema_version": 1,
+                "id": "prewarm",
+                "title": "Provider prewarm",
+                "segments": [
+                    {"provider": "alpha", "voice": "voice-a", "text": "Alpha."},
+                    {"provider": "beta", "voice": "voice-b", "text": "Beta."},
+                    {"provider": "alpha", "voice": "voice-a", "text": "Again."},
+                ],
+            }),
+            encoding="utf-8",
+        )
+        voices.write_text(json.dumps({"presets": []}), encoding="utf-8")
+        return program, voices
+
+    def test_prewarm_selects_only_matching_provider_segments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            program, voices = self.write_program_and_voices(root)
+            provider = ToneProvider("alpha", 440)
+            calls = []
+
+            def fake_render(segment, actual_provider, cache_root):
+                calls.append((segment["text"], actual_provider.name, Path(cache_root)))
+                index = len(calls)
+                return root / f"{index}.mp3", index == 1, f"fp-{index}"
+
+            with (
+                patch(
+                    "audio_engine.provider_cache.build_promoted_providers",
+                    return_value={"alpha": provider},
+                ),
+                patch(
+                    "audio_engine.provider_cache.render_voice_clip",
+                    side_effect=fake_render,
+                ),
+            ):
+                report = prewarm_promoted_provider_cache(
+                    program,
+                    voices,
+                    root / "alpha-package.json",
+                    root / "cache",
+                )
+
+            self.assertEqual([item[0] for item in calls], ["Alpha.", "Again."])
+            self.assertTrue(all(item[1] == "alpha" for item in calls))
+            self.assertEqual(report["provider"], "alpha")
+            self.assertEqual(report["segment_count"], 2)
+            self.assertEqual(report["cache_hits"], 1)
+            self.assertEqual(report["cache_misses"], 1)
+            self.assertEqual(report["fingerprints"], ["fp-1", "fp-2"])
+
+    def test_cache_only_provider_reuses_prewarmed_clip_without_runtime_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            program = root / "program.json"
+            program.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "id": "cache-only-hit",
+                    "title": "Cache only hit",
+                    "segments": [
+                        {"provider": "alpha", "voice": "voice-a", "text": "Alpha."},
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            provider = ToneProvider("alpha", 440)
+            first = render_program(program, root / "out", providers={"alpha": provider})
+            self.assertEqual(provider.calls, 1)
+            shutil.rmtree(root / "out" / "cache-only-hit")
+
+            second = render_program(
+                program,
+                root / "out",
+                providers={"alpha": CacheOnlyProvider(provider)},
+            )
+            self.assertEqual(provider.calls, 1)
+            self.assertEqual(second["mix"]["voice_fingerprints"], first["mix"]["voice_fingerprints"])
+
+    def test_cache_only_provider_fails_closed_on_missing_clip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            program = root / "program.json"
+            program.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "id": "cache-only-miss",
+                    "title": "Cache only miss",
+                    "segments": [
+                        {"provider": "alpha", "voice": "voice-a", "text": "Alpha."},
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            provider = ToneProvider("alpha", 440)
+            with self.assertRaisesRegex(RuntimeError, "cache-only in final render"):
+                render_program(
+                    program,
+                    root / "out",
+                    providers={"alpha": CacheOnlyProvider(provider)},
+                )
+            self.assertEqual(provider.calls, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #251.

Production can now combine multiple promoted local providers with incompatible accepted runtimes without mutating either runtime.

Architecture:
- each promoted provider gets its own Python venv;
- its exact accepted runtime installer runs only inside that venv;
- exact Audio Engine is installed into the venv with --no-deps;
- provider-cache prewarm renders only that provider's Program segments into the shared scene voice cache;
- final scene render runs in the base environment with every promoted local provider forced cache-only;
- any missing local-provider clip fails closed instead of synthesizing in the base environment;
- final render manifest cache identity is checked against each prewarm report;
- prewarm reports are published with the unit evidence;
- Edge remains a normal base-environment provider.

This directly resolves the incompatible P4/S09 runtime pair:
- VoxCPM2: torch 2.7.1+cpu / transformers 5.16.1
- Chatterbox: torch 2.6.0 / transformers 5.2.0

No product-specific logic and no relaxation of provider-package/runtime authority.