### PR TITLE
prod: bootstrap engine imports inside isolated provider runtimes

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -435,6 +435,8 @@ jobs:
                 exit 2
                 ;;
             esac
+            python -m pip install --disable-pip-version-check --no-deps \
+              "imageio-ffmpeg==0.6.0" "edge-tts==7.2.8"
             python -m pip install --disable-pip-version-check --no-deps ./.audio-engine
             audio-engine provider-package hydrate-references "$package" --workspace-root .
             audio-engine provider-package hydrate-model "$package" --cache-root generated/provider-models

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -106,6 +106,8 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         self.assertIn("install_voxcpm2_p4_runtime.sh", self.workflow)
         self.assertIn("requirements/chatterbox-mtl-v3-h1b-runtime.txt", self.workflow)
         self.assertIn("requirements/voxcpm2-p4-runtime.txt", self.workflow)
+        self.assertIn('"imageio-ffmpeg==0.6.0" "edge-tts==7.2.8"', self.workflow)
+        self.assertIn("--disable-pip-version-check --no-deps", self.workflow)
         self.assertIn("--no-deps ./.audio-engine", self.workflow)
         self.assertIn("audio-engine provider-package hydrate-references", self.workflow)
         self.assertIn("audio-engine provider-package hydrate-model", self.workflow)


### PR DESCRIPTION
Closes #257.

Fixes the next real isolated-runtime Production failure observed on Odyssée run 33625303334 / S08:

`ModuleNotFoundError: No module named 'imageio_ffmpeg'`

The provider runtime locks remain authoritative and unchanged.

Inside each isolated provider venv the workflow now installs, with `--no-deps`:
- `imageio-ffmpeg==0.6.0`
- `edge-tts==7.2.8`

Then it installs exact Audio Engine with `--no-deps`, followed by isolated hydrate / validate / prewarm.

This supplies only exact engine import/bootstrap packages and does not resolve or mutate Torch, Transformers, NumPy or any provider-qualified dependency. Final render remains cache-only for promoted providers.