### PR TITLE
prod: one-shot BeltOut conversion and immutable voice clips

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -429,6 +429,9 @@ jobs:
               voxcpm2)
                 bash .audio-engine/scripts/install_voxcpm2_p4_runtime.sh
                 ;;
+              immutable-voice-clips-v1)
+                # No model runtime: references are immutable authored/converted clips.
+                ;;
               *)
                 echo "ERROR: Production provider '$provider_id' has no promoted runtime installer." >&2
                 echo "No fallback is allowed." >&2
@@ -439,7 +442,9 @@ jobs:
               "imageio-ffmpeg==0.6.0" "edge-tts==7.2.8"
             python -m pip install --disable-pip-version-check --no-deps ./.audio-engine
             audio-engine provider-package hydrate-references "$package" --workspace-root .
-            audio-engine provider-package hydrate-model "$package" --cache-root generated/provider-models
+            if [[ "$provider_id" != "immutable-voice-clips-v1" ]]; then
+              audio-engine provider-package hydrate-model "$package" --cache-root generated/provider-models
+            fi
             audio-engine provider-package validate "$package" \
               --verify-files --workspace-root . --voice-pack "$VOICE_PACK"
             audio-engine provider-cache prewarm "$PROGRAM" \

--- a/src/audio_engine/cli.py
+++ b/src/audio_engine/cli.py
@@ -35,6 +35,7 @@ from .sound.library import hydrate_sound_library
 from .sound.selection import select_candidates
 from .timing import timing_report
 from .voices import load_voice_config, public_catalog, recommend_presets
+from .voice_conversion import convert_beltout_once
 
 
 VOICE_LAB_PROVIDER_CANDIDATE_SETS = ("fr", "fr-plus-multilingual")
@@ -222,6 +223,31 @@ def build_parser():
     )
     provider_cache_prewarm.add_argument("--workspace-root", default=".")
 
+    voice_conversion = sub.add_parser(
+        "voice-conversion",
+        help="Run explicit offline voice-conversion primitives",
+    )
+    voice_conversion_sub = voice_conversion.add_subparsers(
+        dest="voice_conversion_command",
+        required=True,
+    )
+    beltout_once = voice_conversion_sub.add_parser(
+        "beltout-once",
+        help="Convert one immutable performance exactly once with pinned BeltOut assets",
+    )
+    beltout_once.add_argument("--source", required=True)
+    beltout_once.add_argument("--source-sha256", required=True)
+    beltout_once.add_argument("--target-reference", required=True)
+    beltout_once.add_argument("--target-reference-sha256", required=True)
+    beltout_once.add_argument("--beltout-source", required=True)
+    beltout_once.add_argument("--expected-revision", required=True)
+    beltout_once.add_argument("--checkpoint-dir", required=True)
+    beltout_once.add_argument("--checkpoint-manifest", required=True)
+    beltout_once.add_argument("--seed", required=True, type=int)
+    beltout_once.add_argument("--n-timesteps", required=True, type=int)
+    beltout_once.add_argument("--out", required=True)
+    beltout_once.add_argument("--report", required=True)
+
     qa = sub.add_parser(
         "qa",
         help="Run deterministic machine QA over one completed render directory",
@@ -377,6 +403,23 @@ def main(argv=None):
                     args.unit,
                     workspace_root=args.workspace_root,
                 )
+        elif args.command == "voice-conversion":
+            result = convert_beltout_once(
+                source=args.source,
+                source_sha256=args.source_sha256,
+                target_reference=args.target_reference,
+                target_reference_sha256=args.target_reference_sha256,
+                beltout_source=args.beltout_source,
+                expected_revision=args.expected_revision,
+                checkpoint_dir=args.checkpoint_dir,
+                checkpoint_manifest=args.checkpoint_manifest,
+                output=args.out,
+                report=args.report,
+                seed=args.seed,
+                n_timesteps=args.n_timesteps,
+            )
+            if result.get("status") != "PASS":
+                exit_code = 2
         elif args.command == "provider-cache":
             if args.report:
                 result = prewarm_promoted_provider_cache_to_file(

--- a/src/audio_engine/providers/factory.py
+++ b/src/audio_engine/providers/factory.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from ..contract import ContractError, load_json
 from ..provider_package import validate_provider_package
 from .chatterbox_mtl_v3 import ChatterboxMultilingualV3Provider
+from .immutable_voice_clips import ImmutableVoiceClipsProvider
 from .voxcpm2 import VoxCPM2Provider
 
 
@@ -63,6 +64,11 @@ def build_promoted_providers(
                 package_path,
                 workspace_root=workspace_root,
                 model_dir=model_dir,
+            )
+        elif provider_id == "immutable-voice-clips-v1":
+            provider = ImmutableVoiceClipsProvider(
+                package_path,
+                workspace_root=workspace_root,
             )
         else:
             raise ContractError(

--- a/src/audio_engine/providers/immutable_voice_clips.py
+++ b/src/audio_engine/providers/immutable_voice_clips.py
@@ -1,0 +1,102 @@
+import hashlib
+import json
+from pathlib import Path
+
+from ..audio import run_ffmpeg
+from ..contract import ContractError, load_json, sha256_file
+from ..provider_package import validate_provider_package
+from .local_runtime import verify_references
+
+_PROVIDER_ID = "immutable-voice-clips-v1"
+_ALLOWED_PARAMETERS = {"reference"}
+
+
+class ImmutableVoiceClipsProvider:
+    """Promoted provider for already-authored immutable voice clips.
+
+    The provider performs no speech synthesis and makes no selection decision.
+    Each Program segment must explicitly name one hash-locked reference from
+    the provider package. The only materialization step is deterministic audio
+    transport into the engine's MP3 voice-cache format.
+    """
+
+    name = _PROVIDER_ID
+    processing = "immutable-local-clip"
+    edge_silence_normalization = False
+
+    def __init__(self, package_path, workspace_root="."):
+        self.package_path = Path(package_path)
+        self.workspace_root = Path(workspace_root).resolve()
+        self.package = validate_provider_package(
+            load_json(self.package_path),
+            package_path=self.package_path,
+            workspace_root=self.workspace_root,
+            verify_files=False,
+        )
+        provider = self.package["provider"]
+        if provider["id"] != self.name:
+            raise ContractError(
+                f"Provider package id {provider['id']!r} does not match adapter {self.name!r}"
+            )
+        self.references = verify_references(
+            self.package,
+            self.workspace_root,
+            "Immutable voice clips",
+        )
+        if not self.references:
+            raise ContractError("Immutable voice clips provider requires at least one reference")
+        self.package_sha256 = sha256_file(self.package_path)
+
+    def cache_identity(self):
+        payload = {
+            "provider": self.name,
+            "adapter_code_sha256": sha256_file(Path(__file__)),
+            "implementation_version": self.package["provider"]["implementation_version"],
+            "package_sha256": self.package_sha256,
+            "references": [
+                {"id": item["id"], "sha256": item["sha256"]}
+                for item in self.package.get("references", [])
+            ],
+        }
+        return hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
+    def _resolved_reference(self, segment):
+        defaults = dict(self.package["synthesis"].get("parameters") or {})
+        overrides = segment.get("provider_parameters") or {}
+        unknown = sorted((set(defaults) | set(overrides)) - _ALLOWED_PARAMETERS)
+        if unknown:
+            raise ContractError(
+                "Unsupported immutable-voice-clips-v1 parameters: "
+                + ", ".join(unknown)
+            )
+        controls = {**defaults, **overrides}
+        reference_id = controls.get("reference")
+        if not isinstance(reference_id, str) or not reference_id:
+            raise ContractError(
+                "immutable-voice-clips-v1 requires provider_parameters.reference "
+                "on every routed segment"
+            )
+        try:
+            return reference_id, self.references[reference_id]
+        except KeyError as exc:
+            raise ContractError(
+                f"Unknown immutable voice clip reference: {reference_id!r}"
+            ) from exc
+
+    def synthesize(self, segment, path):
+        _, source = self._resolved_reference(segment)
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.unlink(missing_ok=True)
+        run_ffmpeg([
+            "-i", str(source),
+            "-map_metadata", "-1",
+            "-ac", "1",
+            "-c:a", "libmp3lame",
+            "-b:a", "96k",
+            str(path),
+        ])
+        if not path.is_file() or path.stat().st_size <= 0:
+            raise RuntimeError("Immutable voice clip transport produced no usable audio")

--- a/src/audio_engine/voice_conversion.py
+++ b/src/audio_engine/voice_conversion.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import math
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from .contract import ContractError
+
+_REQUIRED_CHECKPOINT_ROLES = (
+    "decoder",
+    "pitch",
+    "encoder",
+    "flow",
+    "mel2wav",
+    "speaker",
+    "tokenizer",
+)
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_beltout_checkpoint_manifest(path):
+    path = Path(path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContractError(f"BeltOut checkpoint manifest is invalid: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ContractError("BeltOut checkpoint manifest must be an object")
+    if set(data) != set(_REQUIRED_CHECKPOINT_ROLES):
+        raise ContractError(
+            "BeltOut checkpoint manifest must contain exactly: "
+            + ", ".join(_REQUIRED_CHECKPOINT_ROLES)
+        )
+    for role in _REQUIRED_CHECKPOINT_ROLES:
+        item = data[role]
+        if not isinstance(item, dict):
+            raise ContractError(f"BeltOut checkpoint role {role!r} must be an object")
+        filename = item.get("file")
+        digest = item.get("sha256")
+        if (
+            not isinstance(filename, str)
+            or not filename
+            or Path(filename).is_absolute()
+            or ".." in Path(filename).parts
+        ):
+            raise ContractError(f"BeltOut checkpoint role {role!r} has unsafe file")
+        if not isinstance(digest, str) or not _SHA256_RE.fullmatch(digest):
+            raise ContractError(
+                f"BeltOut checkpoint role {role!r} needs lowercase SHA-256"
+            )
+    return data
+
+
+def _verify_git_revision(source_root: Path, expected_revision: str):
+    if not _GIT_SHA_RE.fullmatch(str(expected_revision or "")):
+        raise ContractError("BeltOut expected revision must be an exact 40-char Git SHA")
+    if not source_root.is_dir():
+        raise ContractError(f"BeltOut source directory not found: {source_root}")
+    try:
+        probe = subprocess.run(
+            ["git", "-C", str(source_root), "rev-parse", "HEAD"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError as exc:
+        raise ContractError(f"Unable to inspect BeltOut Git revision: {exc}") from exc
+    actual = (probe.stdout or "").strip()
+    if probe.returncode != 0 or actual != expected_revision:
+        raise ContractError(
+            f"BeltOut source revision mismatch: {actual or 'unavailable'} != {expected_revision}"
+        )
+    return actual
+
+
+def verify_beltout_conversion_inputs(
+    *,
+    source,
+    source_sha256,
+    target_reference,
+    target_reference_sha256,
+    beltout_source,
+    expected_revision,
+    checkpoint_dir,
+    checkpoint_manifest,
+    output,
+    report,
+    seed,
+    n_timesteps,
+):
+    source = Path(source).resolve()
+    target_reference = Path(target_reference).resolve()
+    beltout_source = Path(beltout_source).resolve()
+    checkpoint_dir = Path(checkpoint_dir).resolve()
+    output = Path(output).resolve()
+    report = Path(report).resolve()
+
+    if output.exists() or report.exists():
+        raise ContractError(
+            "BeltOut one-shot output/report already exists; retry or best-of-N is forbidden"
+        )
+    if output == report:
+        raise ContractError("BeltOut output and report paths must differ")
+    if not source.is_file():
+        raise ContractError(f"BeltOut source performance not found: {source}")
+    if not target_reference.is_file():
+        raise ContractError(f"BeltOut target reference not found: {target_reference}")
+    if not checkpoint_dir.is_dir():
+        raise ContractError(f"BeltOut checkpoint directory not found: {checkpoint_dir}")
+    if not isinstance(seed, int) or isinstance(seed, bool) or seed < 0:
+        raise ContractError("BeltOut seed must be a non-negative integer")
+    if not isinstance(n_timesteps, int) or isinstance(n_timesteps, bool) or n_timesteps <= 0:
+        raise ContractError("BeltOut n_timesteps must be a positive integer")
+    if not _SHA256_RE.fullmatch(str(source_sha256 or "")):
+        raise ContractError("BeltOut source SHA-256 must be exact lowercase hex")
+    if not _SHA256_RE.fullmatch(str(target_reference_sha256 or "")):
+        raise ContractError("BeltOut target reference SHA-256 must be exact lowercase hex")
+    actual_source_sha = _sha256(source)
+    if actual_source_sha != source_sha256:
+        raise ContractError(
+            f"BeltOut source SHA-256 mismatch: {actual_source_sha} != {source_sha256}"
+        )
+    actual_target_sha = _sha256(target_reference)
+    if actual_target_sha != target_reference_sha256:
+        raise ContractError(
+            f"BeltOut target reference SHA-256 mismatch: {actual_target_sha} != {target_reference_sha256}"
+        )
+
+    revision = _verify_git_revision(beltout_source, expected_revision)
+    manifest = load_beltout_checkpoint_manifest(checkpoint_manifest)
+    verified_checkpoints = {}
+    for role in _REQUIRED_CHECKPOINT_ROLES:
+        item = manifest[role]
+        target = (checkpoint_dir / item["file"]).resolve()
+        try:
+            target.relative_to(checkpoint_dir)
+        except ValueError as exc:
+            raise ContractError(
+                f"BeltOut checkpoint escapes checkpoint directory: {item['file']}"
+            ) from exc
+        if not target.is_file():
+            raise ContractError(f"BeltOut checkpoint missing: {item['file']}")
+        actual = _sha256(target)
+        if actual != item["sha256"]:
+            raise ContractError(
+                f"BeltOut checkpoint SHA-256 mismatch for {role}: "
+                f"{actual} != {item['sha256']}"
+            )
+        verified_checkpoints[role] = {
+            "path": str(target),
+            "file": item["file"],
+            "sha256": actual,
+        }
+
+    return {
+        "source": source,
+        "source_sha256": actual_source_sha,
+        "target_reference": target_reference,
+        "target_reference_sha256": actual_target_sha,
+        "beltout_source": beltout_source,
+        "expected_revision": revision,
+        "checkpoint_dir": checkpoint_dir,
+        "checkpoints": verified_checkpoints,
+        "output": output,
+        "report": report,
+        "seed": seed,
+        "n_timesteps": n_timesteps,
+    }
+
+
+def _cosine(torch, functional, a, b):
+    a = a.detach().float().reshape(1, -1).cpu()
+    b = b.detach().float().reshape(1, -1).cpu()
+    return float(functional.cosine_similarity(a, b, dim=1).item())
+
+
+def _convert_with_beltout(validated):
+    try:
+        import librosa
+        import numpy as np
+        import soundfile as sf
+        import torch
+        import torch.nn.functional as F
+        import torchaudio
+        import torchcrepe
+    except ImportError as exc:
+        raise ContractError(
+            "BeltOut Production runtime dependencies are incomplete"
+        ) from exc
+
+    source_root = validated["beltout_source"]
+    source_module_root = str(source_root / "src")
+    inserted = False
+    if source_module_root not in sys.path:
+        sys.path.insert(0, source_module_root)
+        inserted = True
+    try:
+        try:
+            beltout_module = importlib.import_module("beltout")
+            BeltOutTTM = beltout_module.BeltOutTTM
+        except (ImportError, AttributeError) as exc:
+            raise ContractError("Pinned BeltOut source cannot be imported") from exc
+
+        checkpoints = validated["checkpoints"]
+        model = BeltOutTTM.from_local(
+            checkpoints["decoder"]["path"],
+            checkpoints["pitch"]["path"],
+            checkpoints["encoder"]["path"],
+            checkpoints["flow"]["path"],
+            checkpoints["mel2wav"]["path"],
+            checkpoints["speaker"]["path"],
+            checkpoints["tokenizer"]["path"],
+            device="cpu",
+        )
+
+        source_wav, _ = librosa.load(
+            validated["source"],
+            sr=model.sr,
+            mono=True,
+        )
+        target_wav, _ = librosa.load(
+            validated["target_reference"],
+            sr=model.sr,
+            mono=True,
+        )
+        if len(source_wav) == 0 or len(target_wav) == 0:
+            raise ContractError("BeltOut source and target reference must contain audio")
+
+        source_t = torch.from_numpy(source_wav).float().unsqueeze(0)
+        target_t = torch.from_numpy(target_wav).float().unsqueeze(0)
+        with torch.inference_mode():
+            source_x = model.embed_ref_x_vector(source_t, model.sr, device="cpu")
+            target_x = model.embed_ref_x_vector(target_t, model.sr, device="cpu")
+
+        torch.manual_seed(validated["seed"])
+        np.random.seed(validated["seed"] % (2**32 - 1))
+        torch.set_num_threads(2)
+
+        wav24 = source_t.to("cpu")
+        wav16 = torchaudio.functional.resample(wav24, model.sr, 16000)
+        with torch.inference_mode():
+            s3_tokens, _ = model.tokenizer(wav16)
+            speaker_embedding = model.flow.spk_embed_affine_layer(target_x.to("cpu"))
+            token_embeddings = model.flow.input_embedding(s3_tokens)
+            token_len = torch.tensor([token_embeddings.shape[1]], device="cpu")
+            hidden, _ = model.encoder(token_embeddings, token_len)
+            encoded_tokens = model.flow.encoder_proj(hidden)
+            mu = encoded_tokens.transpose(1, 2)
+            mel_len = mu.shape[2]
+
+            crepe_sr = 16000
+            hop = int(crepe_sr / 100.0)
+            frames_per_mel = 2
+            samples_needed = mel_len * frames_per_mel * hop
+            padded = wav16
+            pad = samples_needed - padded.shape[1]
+            if pad > 0:
+                padded = F.pad(padded, (0, pad))
+
+            crepe_embedding = torchcrepe.embed(
+                padded,
+                crepe_sr,
+                hop_length=hop,
+                model="tiny",
+                device="cpu",
+            )
+            crepe_embedding = crepe_embedding[:, : mel_len * 2, :, :]
+            projector_input = crepe_embedding.reshape(-1, frames_per_mel, 256)
+            pitch_flat = model.pitchmvmt(projector_input)
+            pitch = pitch_flat.reshape(1, -1, 80).transpose(1, 2)
+
+            mask = torch.ones(1, 1, mu.shape[2], device="cpu", dtype=torch.bool)
+            output_mels, _ = model.decoder(
+                mu=mu,
+                mask=mask,
+                spks=speaker_embedding,
+                cond=pitch,
+                n_timesteps=validated["n_timesteps"],
+            )
+            output_wav, _ = model.mel2wav.inference(speech_feat=output_mels)
+
+        converted = output_wav.squeeze().detach().cpu().numpy().astype(np.float32)
+        source_duration = float(len(source_wav) / model.sr)
+        converted_duration = float(len(converted) / model.sr)
+
+        temp_output = validated["output"].with_suffix(
+            validated["output"].suffix + ".tmp"
+        )
+        temp_output.parent.mkdir(parents=True, exist_ok=True)
+        temp_output.unlink(missing_ok=True)
+        sf.write(temp_output, converted, model.sr, subtype="PCM_16", format="WAV")
+        temp_output.replace(validated["output"])
+
+        output_read, output_sr = sf.read(
+            validated["output"],
+            dtype="float32",
+            always_2d=False,
+        )
+        output_np = np.asarray(output_read, dtype=np.float32)
+        if output_np.ndim == 2:
+            output_np = output_np.mean(axis=1)
+        finite = bool(np.isfinite(output_np).all())
+        rms = float(np.sqrt(np.mean(np.square(output_np)))) if len(output_np) else 0.0
+        peak = float(np.max(np.abs(output_np))) if len(output_np) else 0.0
+        technical_pass = (
+            finite
+            and output_sr > 0
+            and 0.20 <= converted_duration <= 30.0
+            and 0.0015 <= rms <= 0.8
+            and peak <= 1.0
+        )
+
+        output_t = torch.from_numpy(output_np).float().unsqueeze(0)
+        with torch.inference_mode():
+            output_x = model.embed_ref_x_vector(output_t, output_sr, device="cpu")
+        source_to_target = _cosine(torch, F, source_x, target_x)
+        output_to_target = _cosine(torch, F, output_x, target_x)
+        output_to_source = _cosine(torch, F, output_x, source_x)
+        identity_direction_pass = (
+            output_to_target > source_to_target
+            and output_to_target > output_to_source
+        )
+        duration_ratio = (
+            converted_duration / source_duration if source_duration else math.inf
+        )
+        duration_pass = 0.75 <= duration_ratio <= 1.25
+
+        return {
+            "technical": {
+                "status": "PASS" if technical_pass else "REJECT",
+                "sample_rate": int(output_sr),
+                "duration_seconds": converted_duration,
+                "rms": rms,
+                "peak": peak,
+                "finite": finite,
+            },
+            "source_duration_seconds": source_duration,
+            "output_duration_seconds": converted_duration,
+            "duration_ratio": duration_ratio,
+            "duration_pass": duration_pass,
+            "speaker_embedding": {
+                "cosine_source_to_target": source_to_target,
+                "cosine_output_to_target": output_to_target,
+                "cosine_output_to_source": output_to_source,
+                "direction_pass": identity_direction_pass,
+            },
+            "pass": bool(
+                technical_pass and duration_pass and identity_direction_pass
+            ),
+        }
+    finally:
+        if inserted:
+            try:
+                sys.path.remove(source_module_root)
+            except ValueError:
+                pass
+
+
+def convert_beltout_once(
+    *,
+    source,
+    source_sha256,
+    target_reference,
+    target_reference_sha256,
+    beltout_source,
+    expected_revision,
+    checkpoint_dir,
+    checkpoint_manifest,
+    output,
+    report,
+    seed,
+    n_timesteps,
+):
+    validated = verify_beltout_conversion_inputs(
+        source=source,
+        source_sha256=source_sha256,
+        target_reference=target_reference,
+        target_reference_sha256=target_reference_sha256,
+        beltout_source=beltout_source,
+        expected_revision=expected_revision,
+        checkpoint_dir=checkpoint_dir,
+        checkpoint_manifest=checkpoint_manifest,
+        output=output,
+        report=report,
+        seed=seed,
+        n_timesteps=n_timesteps,
+    )
+    evidence = _convert_with_beltout(validated)
+    result = {
+        "schema_version": 1,
+        "status": "PASS" if evidence["pass"] else "REJECT",
+        "operation": "beltout-once",
+        "retry_allowed_after_output": False,
+        "network_used": False,
+        "fallback": "fail",
+        "inputs": {
+            "source_sha256": validated["source_sha256"],
+            "target_reference_sha256": validated["target_reference_sha256"],
+            "beltout_revision": validated["expected_revision"],
+            "checkpoints": {
+                role: {
+                    "file": item["file"],
+                    "sha256": item["sha256"],
+                }
+                for role, item in validated["checkpoints"].items()
+            },
+        },
+        "conversion": {
+            "seed": validated["seed"],
+            "n_timesteps": validated["n_timesteps"],
+            "best_of_n": False,
+            "second_pass": False,
+            "time_stretch": False,
+            "pitch_shift": False,
+            "emotion_dsp": False,
+        },
+        "output": {
+            "path": str(validated["output"]),
+            "sha256": _sha256(validated["output"]),
+        },
+        "evidence": evidence,
+    }
+    report_path = validated["report"]
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_report = report_path.with_suffix(report_path.suffix + ".tmp")
+    temp_report.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    temp_report.replace(report_path)
+    return result

--- a/tests/test_immutable_voice_clips_provider.py
+++ b/tests/test_immutable_voice_clips_provider.py
@@ -1,0 +1,129 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from audio_engine.contract import ContractError
+from audio_engine.providers.factory import build_promoted_providers
+from audio_engine.providers.immutable_voice_clips import ImmutableVoiceClipsProvider
+
+
+def sha(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+class ImmutableVoiceClipsProviderTests(unittest.TestCase):
+    def make_fixture(self, root):
+        root = Path(root)
+        clip = root / "clip.wav"
+        clip.write_bytes(b"RIFF-immutable-converted-clip")
+        voices = root / "voices.json"
+        voices.write_text('{"presets":[]}', encoding="utf-8")
+        package = {
+            "schema_version": 1,
+            "id": "immutable-clips-test",
+            "provider": {
+                "id": "immutable-voice-clips-v1",
+                "implementation_version": "1.0.0",
+            },
+            "runtime": {
+                "kind": "python",
+                "python": "3.12",
+                "device": "cpu",
+                "dependencies": [
+                    {"name": "recit-audio-engine", "version": "0.9.2"},
+                ],
+            },
+            "model": {
+                "id": "immutable-local-clips",
+                "source": "local",
+                "revision": "bundle-v1",
+                "integrity": [
+                    {
+                        "name": "clip.wav",
+                        "path": "clip.wav",
+                        "sha256": sha(clip),
+                    }
+                ],
+            },
+            "voice_pack_sha256": sha(voices),
+            "synthesis": {"seed": 0, "parameters": {}},
+            "references": [
+                {"id": "slot-1", "path": "clip.wav", "sha256": sha(clip)}
+            ],
+            "fallback": "fail",
+        }
+        package_path = root / "provider.json"
+        package_path.write_text(json.dumps(package), encoding="utf-8")
+        return package_path, clip
+
+    def test_factory_promotes_provider_and_hash_locks_reference(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_path, _ = self.make_fixture(tmp)
+            providers = build_promoted_providers(
+                [package_path],
+                workspace_root=tmp,
+            )
+            provider = providers["immutable-voice-clips-v1"]
+            self.assertIsInstance(provider, ImmutableVoiceClipsProvider)
+            self.assertEqual(len(provider.cache_identity()), 64)
+            self.assertFalse(provider.edge_silence_normalization)
+
+    def test_segment_must_explicitly_name_one_reference(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_path, _ = self.make_fixture(tmp)
+            provider = ImmutableVoiceClipsProvider(package_path, workspace_root=tmp)
+            with self.assertRaisesRegex(ContractError, "provider_parameters.reference"):
+                provider._resolved_reference({
+                    "sequence": 1,
+                    "text": "Exact authored line.",
+                    "voice": "identity",
+                })
+
+    def test_unknown_reference_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_path, _ = self.make_fixture(tmp)
+            provider = ImmutableVoiceClipsProvider(package_path, workspace_root=tmp)
+            with self.assertRaisesRegex(ContractError, "Unknown immutable voice clip"):
+                provider._resolved_reference({
+                    "sequence": 1,
+                    "text": "Exact authored line.",
+                    "voice": "identity",
+                    "provider_parameters": {"reference": "wrong"},
+                })
+
+    def test_synthesize_only_transcodes_exact_selected_reference(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package_path, clip = self.make_fixture(tmp)
+            provider = ImmutableVoiceClipsProvider(package_path, workspace_root=tmp)
+            output = Path(tmp) / "out.mp3"
+            observed = {}
+
+            def fake_ffmpeg(args):
+                observed["args"] = list(args)
+                output.write_bytes(b"mp3")
+
+            with patch(
+                "audio_engine.providers.immutable_voice_clips.run_ffmpeg",
+                side_effect=fake_ffmpeg,
+            ):
+                provider.synthesize({
+                    "sequence": 1,
+                    "text": "Exact authored line.",
+                    "voice": "identity",
+                    "provider_parameters": {"reference": "slot-1"},
+                }, output)
+
+            self.assertTrue(output.is_file())
+            self.assertIn(str(clip), observed["args"])
+            joined = " ".join(observed["args"])
+            self.assertNotIn("-af", observed["args"])
+            self.assertNotIn("volume=", joined)
+            self.assertNotIn("atempo=", joined)
+            self.assertNotIn("asetrate=", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_production_workflow_contract.py
+++ b/tests/test_production_workflow_contract.py
@@ -119,6 +119,17 @@ class ProductionWorkflowContractTests(unittest.TestCase):
         self.assertIn("promoted_provider_not_cache_only", self.workflow)
         self.assertIn('cp -R "$work/provider-prewarm" "$publish/provider-prewarm"', self.workflow)
 
+    def test_immutable_clip_provider_needs_no_model_runtime(self):
+        self.assertIn("immutable-voice-clips-v1)", self.workflow)
+        self.assertIn(
+            'if [[ "$provider_id" != "immutable-voice-clips-v1" ]]',
+            self.workflow,
+        )
+        self.assertIn(
+            "No model runtime: references are immutable authored/converted clips.",
+            self.workflow,
+        )
+
     def test_provider_prewarm_and_binding_evidence_are_structured_and_explicit(self):
         self.assertIn('--report "$report_root/$safe_id.json"', self.workflow)
         self.assertNotIn('> "$report_root/$safe_id.json"', self.workflow)

--- a/tests/test_voice_conversion.py
+++ b/tests/test_voice_conversion.py
@@ -1,0 +1,190 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from audio_engine.cli import build_parser
+from audio_engine.contract import ContractError
+from audio_engine.voice_conversion import (
+    convert_beltout_once,
+    load_beltout_checkpoint_manifest,
+    verify_beltout_conversion_inputs,
+)
+
+
+ROLES = ("decoder", "pitch", "encoder", "flow", "mel2wav", "speaker", "tokenizer")
+
+
+def sha_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+class BeltOutVoiceConversionTests(unittest.TestCase):
+    def checkpoint_manifest(self, root):
+        data = {
+            role: {"file": f"{role}.bin", "sha256": sha_bytes(role.encode())}
+            for role in ROLES
+        }
+        path = Path(root) / "checkpoints.json"
+        path.write_text(json.dumps(data), encoding="utf-8")
+        return path
+
+    def test_checkpoint_manifest_requires_exact_roles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.checkpoint_manifest(tmp)
+            parsed = load_beltout_checkpoint_manifest(path)
+            self.assertEqual(set(parsed), set(ROLES))
+            data = json.loads(path.read_text(encoding="utf-8"))
+            data.pop("pitch")
+            path.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaisesRegex(ContractError, "must contain exactly"):
+                load_beltout_checkpoint_manifest(path)
+
+    def test_existing_output_blocks_one_shot_before_runtime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source.wav"
+            target = root / "target.wav"
+            source.write_bytes(b"source")
+            target.write_bytes(b"target")
+            output = root / "out.wav"
+            output.write_bytes(b"already-generated")
+            with self.assertRaisesRegex(ContractError, "retry or best-of-N is forbidden"):
+                verify_beltout_conversion_inputs(
+                    source=source,
+                    source_sha256=sha_bytes(b"source"),
+                    target_reference=target,
+                    target_reference_sha256=sha_bytes(b"target"),
+                    beltout_source=root / "beltout",
+                    expected_revision="a" * 40,
+                    checkpoint_dir=root / "checkpoints",
+                    checkpoint_manifest=self.checkpoint_manifest(root),
+                    output=output,
+                    report=root / "report.json",
+                    seed=1,
+                    n_timesteps=10,
+                )
+
+    def test_wrong_source_hash_fails_before_model_runtime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source.wav"
+            target = root / "target.wav"
+            source.write_bytes(b"source")
+            target.write_bytes(b"target")
+            checkpoints = root / "checkpoints"
+            checkpoints.mkdir()
+            with self.assertRaisesRegex(ContractError, "source SHA-256 mismatch"):
+                verify_beltout_conversion_inputs(
+                    source=source,
+                    source_sha256="0" * 64,
+                    target_reference=target,
+                    target_reference_sha256=sha_bytes(b"target"),
+                    beltout_source=root / "beltout",
+                    expected_revision="a" * 40,
+                    checkpoint_dir=checkpoints,
+                    checkpoint_manifest=self.checkpoint_manifest(root),
+                    output=root / "out.wav",
+                    report=root / "report.json",
+                    seed=1,
+                    n_timesteps=10,
+                )
+
+    def test_success_report_binds_inputs_conversion_and_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output = root / "out.wav"
+            report = root / "report.json"
+            validated = {
+                "source": root / "source.wav",
+                "source_sha256": "1" * 64,
+                "target_reference": root / "target.wav",
+                "target_reference_sha256": "2" * 64,
+                "beltout_source": root / "beltout",
+                "expected_revision": "3" * 40,
+                "checkpoint_dir": root / "checkpoints",
+                "checkpoints": {
+                    role: {
+                        "file": f"{role}.bin",
+                        "path": str(root / f"{role}.bin"),
+                        "sha256": sha_bytes(role.encode()),
+                    }
+                    for role in ROLES
+                },
+                "output": output,
+                "report": report,
+                "seed": 42,
+                "n_timesteps": 10,
+            }
+
+            def fake_convert(actual):
+                actual["output"].write_bytes(b"converted")
+                return {
+                    "technical": {"status": "PASS"},
+                    "source_duration_seconds": 1.0,
+                    "output_duration_seconds": 1.0,
+                    "duration_ratio": 1.0,
+                    "duration_pass": True,
+                    "speaker_embedding": {"direction_pass": True},
+                    "pass": True,
+                }
+
+            with (
+                patch(
+                    "audio_engine.voice_conversion.verify_beltout_conversion_inputs",
+                    return_value=validated,
+                ),
+                patch(
+                    "audio_engine.voice_conversion._convert_with_beltout",
+                    side_effect=fake_convert,
+                ),
+            ):
+                result = convert_beltout_once(
+                    source="unused",
+                    source_sha256="1" * 64,
+                    target_reference="unused",
+                    target_reference_sha256="2" * 64,
+                    beltout_source="unused",
+                    expected_revision="3" * 40,
+                    checkpoint_dir="unused",
+                    checkpoint_manifest="unused",
+                    output=output,
+                    report=report,
+                    seed=42,
+                    n_timesteps=10,
+                )
+
+            self.assertEqual(result["status"], "PASS")
+            self.assertFalse(result["retry_allowed_after_output"])
+            self.assertFalse(result["conversion"]["best_of_n"])
+            self.assertFalse(result["conversion"]["second_pass"])
+            self.assertEqual(result["output"]["sha256"], sha_bytes(b"converted"))
+            self.assertEqual(json.loads(report.read_text(encoding="utf-8")), result)
+
+    def test_cli_exposes_explicit_one_shot_arguments(self):
+        args = build_parser().parse_args([
+            "voice-conversion",
+            "beltout-once",
+            "--source", "source.wav",
+            "--source-sha256", "1" * 64,
+            "--target-reference", "target.wav",
+            "--target-reference-sha256", "2" * 64,
+            "--beltout-source", "beltout",
+            "--expected-revision", "3" * 40,
+            "--checkpoint-dir", "checkpoints",
+            "--checkpoint-manifest", "checkpoints.json",
+            "--seed", "42",
+            "--n-timesteps", "10",
+            "--out", "out.wav",
+            "--report", "report.json",
+        ])
+        self.assertEqual(args.command, "voice-conversion")
+        self.assertEqual(args.voice_conversion_command, "beltout-once")
+        self.assertEqual(args.seed, 42)
+        self.assertEqual(args.n_timesteps, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #264.

Adds the generic Production boundary needed after an accepted human-performance -> BeltOut capability:

- offline `audio-engine voice-conversion beltout-once`;
- exact source/target SHA-256 verification;
- exact BeltOut Git revision and seven checkpoint SHA-256 verification;
- explicit seed/timesteps;
- one-shot fail-closed output/report contract; no best-of-N or second pass;
- structured technical/duration/identity-direction evidence;
- promoted `immutable-voice-clips-v1` provider for hash-locked converted clips;
- Production workflow prewarm/cache-only support with no model hydration for immutable clips;
- tests for one-shot/retry prohibition, reference selection and workflow routing.

No Odyssée-specific locators, hashes, text or artistic decisions are embedded in Audio Engine.