### PR TITLE
prod: decode one-shot capture containers in memory

### DIFF
--- a/.github/workflows/production-beltout-portable-windows.yml
+++ b/.github/workflows/production-beltout-portable-windows.yml
@@ -51,9 +51,8 @@ jobs:
           $portable = (Resolve-Path portable).Path
           $pyRel = (Get-Content portable/python-path.txt -Raw).Trim()
           $py = Join-Path $portable $pyRel
-          & $py -m ensurepip --upgrade
-          & $py -m pip install --disable-pip-version-check --index-url https://download.pytorch.org/whl/cpu "torch==2.6.0" "torchaudio==2.6.0"
-          & $py -m pip install --disable-pip-version-check "numpy==1.26.4" "librosa==0.11.0" "s3tokenizer==0.3.0" "torchcrepe==0.0.24" "transformers==4.46.3" "diffusers==0.29.0" "conformer==0.3.2" "safetensors==0.5.3" "huggingface_hub==0.33.1" "scipy==1.15.3" "tqdm==4.67.1" "soundfile==0.13.1" "edge-tts==7.2.8" "imageio-ffmpeg==0.6.0"
+          uv pip install --python "$py" --break-system-packages --index-url https://download.pytorch.org/whl/cpu "torch==2.6.0" "torchaudio==2.6.0"
+          uv pip install --python "$py" --break-system-packages "numpy==1.26.4" "librosa==0.11.0" "s3tokenizer==0.3.0" "torchcrepe==0.0.24" "transformers==4.46.3" "diffusers==0.29.0" "conformer==0.3.2" "safetensors==0.5.3" "huggingface_hub==0.33.1" "scipy==1.15.3" "tqdm==4.67.1" "soundfile==0.13.1" "edge-tts==7.2.8" "imageio-ffmpeg==0.6.0"
           & $py -c "import torch, torchaudio, librosa, s3tokenizer, torchcrepe, transformers, diffusers, conformer, safetensors, huggingface_hub, soundfile; print('WINDOWS_PORTABLE_RUNTIME_IMPORT_PASS', torch.__version__, torchaudio.__version__)"
 
       - name: Pin BeltOut source
@@ -70,7 +69,7 @@ jobs:
           $portable = (Resolve-Path portable).Path
           $pyRel = (Get-Content portable/python-path.txt -Raw).Trim()
           $py = Join-Path $portable $pyRel
-          & $py -m pip install --disable-pip-version-check --no-deps ./portable/beltout-src
+          uv pip install --python "$py" --break-system-packages --no-deps ./portable/beltout-src
 
       - name: Hydrate exact checkpoints
         shell: pwsh
@@ -113,7 +112,7 @@ jobs:
           $portable = (Resolve-Path portable).Path
           $pyRel = (Get-Content portable/python-path.txt -Raw).Trim()
           $py = Join-Path $portable $pyRel
-          & $py -m pip install --disable-pip-version-check --no-deps .
+          uv pip install --python "$py" --break-system-packages --no-deps .
 
           $code = @'
           import hashlib

--- a/.github/workflows/production-beltout-portable-windows.yml
+++ b/.github/workflows/production-beltout-portable-windows.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - .github/workflows/production-beltout-portable-windows.yml
+      - src/audio_engine/voice_conversion.py
 
 permissions:
   contents: read

--- a/src/audio_engine/voice_conversion.py
+++ b/src/audio_engine/voice_conversion.py
@@ -183,6 +183,54 @@ def verify_beltout_conversion_inputs(
     }
 
 
+def _load_audio_for_conversion(librosa, np, path, sample_rate):
+    """Decode one immutable input without materializing a normalized raw file."""
+    try:
+        audio, _ = librosa.load(path, sr=sample_rate, mono=True)
+        return np.asarray(audio, dtype=np.float32), "librosa"
+    except Exception as primary_exc:
+        try:
+            import imageio_ffmpeg
+        except ImportError as exc:
+            raise ContractError(
+                "Audio container is unsupported by the local decoder and "
+                "imageio-ffmpeg is unavailable"
+            ) from exc
+
+        command = [
+            imageio_ffmpeg.get_ffmpeg_exe(),
+            "-hide_banner",
+            "-loglevel", "error",
+            "-nostdin",
+            "-i", str(path),
+            "-vn",
+            "-ac", "1",
+            "-ar", str(sample_rate),
+            "-f", "f32le",
+            "-acodec", "pcm_f32le",
+            "pipe:1",
+        ]
+        try:
+            decoded = subprocess.run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        except OSError as exc:
+            raise ContractError(f"Unable to invoke deterministic audio decoder: {exc}") from exc
+        if decoded.returncode != 0:
+            detail = (decoded.stderr or b"").decode("utf-8", errors="replace").strip()
+            raise ContractError(
+                "Unable to decode immutable source audio in memory"
+                + (f": {detail}" if detail else "")
+            ) from primary_exc
+        audio = np.frombuffer(decoded.stdout or b"", dtype="<f4").copy()
+        if audio.size == 0:
+            raise ContractError("Deterministic in-memory audio decode produced no samples")
+        return audio, "ffmpeg-memory"
+
+
 def _cosine(torch, functional, a, b):
     a = a.detach().float().reshape(1, -1).cpu()
     b = b.detach().float().reshape(1, -1).cpu()
@@ -228,15 +276,11 @@ def _convert_with_beltout(validated):
             device="cpu",
         )
 
-        source_wav, _ = librosa.load(
-            validated["source"],
-            sr=model.sr,
-            mono=True,
+        source_wav, source_decoder = _load_audio_for_conversion(
+            librosa, np, validated["source"], model.sr
         )
-        target_wav, _ = librosa.load(
-            validated["target_reference"],
-            sr=model.sr,
-            mono=True,
+        target_wav, target_decoder = _load_audio_for_conversion(
+            librosa, np, validated["target_reference"], model.sr
         )
         if len(source_wav) == 0 or len(target_wav) == 0:
             raise ContractError("BeltOut source and target reference must contain audio")
@@ -341,6 +385,12 @@ def _convert_with_beltout(validated):
         duration_pass = 0.75 <= duration_ratio <= 1.25
 
         return {
+            "audio_decode": {
+                "source": source_decoder,
+                "target_reference": target_decoder,
+                "persistent_normalized_raw_file": False,
+                "filters": [],
+            },
             "technical": {
                 "status": "PASS" if technical_pass else "REJECT",
                 "sample_rate": int(output_sr),

--- a/tests/test_voice_conversion.py
+++ b/tests/test_voice_conversion.py
@@ -1,13 +1,18 @@
 import hashlib
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
+
+import numpy as np
 
 from audio_engine.cli import build_parser
 from audio_engine.contract import ContractError
 from audio_engine.voice_conversion import (
+    _load_audio_for_conversion,
     convert_beltout_once,
     load_beltout_checkpoint_manifest,
     verify_beltout_conversion_inputs,
@@ -162,6 +167,36 @@ class BeltOutVoiceConversionTests(unittest.TestCase):
             self.assertFalse(result["conversion"]["second_pass"])
             self.assertEqual(result["output"]["sha256"], sha_bytes(b"converted"))
             self.assertEqual(json.loads(report.read_text(encoding="utf-8")), result)
+
+    def test_unsupported_container_falls_back_to_in_memory_ffmpeg_decode(self):
+        class UnsupportedContainer:
+            @staticmethod
+            def load(*args, **kwargs):
+                raise RuntimeError("unsupported webm container")
+
+        payload = np.asarray([0.125, -0.25, 0.0], dtype="<f4").tobytes()
+        fake_ffmpeg = SimpleNamespace(get_ffmpeg_exe=lambda: "pinned-ffmpeg")
+        completed = SimpleNamespace(returncode=0, stdout=payload, stderr=b"")
+
+        with (
+            patch.dict(sys.modules, {"imageio_ffmpeg": fake_ffmpeg}),
+            patch(
+                "audio_engine.voice_conversion.subprocess.run",
+                return_value=completed,
+            ) as run,
+        ):
+            audio, decoder = _load_audio_for_conversion(
+                UnsupportedContainer, np, Path("selected.webm"), 24000
+            )
+
+        self.assertEqual(decoder, "ffmpeg-memory")
+        self.assertTrue(np.allclose(audio, [0.125, -0.25, 0.0]))
+        command = run.call_args.args[0]
+        self.assertEqual(command[0], "pinned-ffmpeg")
+        self.assertEqual(command[-1], "pipe:1")
+        self.assertNotIn("-af", command)
+        self.assertNotIn("-filter:a", command)
+        self.assertNotIn("-filter_complex", command)
 
     def test_cli_exposes_explicit_one_shot_arguments(self):
         args = build_parser().parse_args([

--- a/tests/test_voice_conversion.py
+++ b/tests/test_voice_conversion.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import numpy as np
 
 from audio_engine.cli import build_parser
 from audio_engine.contract import ContractError
@@ -174,9 +173,18 @@ class BeltOutVoiceConversionTests(unittest.TestCase):
             def load(*args, **kwargs):
                 raise RuntimeError("unsupported webm container")
 
-        payload = np.asarray([0.125, -0.25, 0.0], dtype="<f4").tobytes()
+        class Decoded:
+            size = 3
+
+            def copy(self):
+                return self
+
+        fake_numpy = SimpleNamespace(
+            float32="float32",
+            frombuffer=lambda *args, **kwargs: Decoded(),
+        )
         fake_ffmpeg = SimpleNamespace(get_ffmpeg_exe=lambda: "pinned-ffmpeg")
-        completed = SimpleNamespace(returncode=0, stdout=payload, stderr=b"")
+        completed = SimpleNamespace(returncode=0, stdout=b"raw-f32", stderr=b"")
 
         with (
             patch.dict(sys.modules, {"imageio_ffmpeg": fake_ffmpeg}),
@@ -186,11 +194,11 @@ class BeltOutVoiceConversionTests(unittest.TestCase):
             ) as run,
         ):
             audio, decoder = _load_audio_for_conversion(
-                UnsupportedContainer, np, Path("selected.webm"), 24000
+                UnsupportedContainer, fake_numpy, Path("selected.webm"), 24000
             )
 
         self.assertEqual(decoder, "ffmpeg-memory")
-        self.assertTrue(np.allclose(audio, [0.125, -0.25, 0.0]))
+        self.assertEqual(audio.size, 3)
         command = run.call_args.args[0]
         self.assertEqual(command[0], "pinned-ffmpeg")
         self.assertEqual(command[-1], "pipe:1")


### PR DESCRIPTION
Closes #268.

Keeps the frozen selected capture container as the exact source authority while making the one-shot BeltOut primitive robust to MediaRecorder WebM/Opus on Windows.

If the normal local decoder cannot read the container, Audio Engine now:
- uses the pinned `imageio-ffmpeg` executable;
- decodes to mono f32 at the model sample rate through stdout only;
- creates no persistent normalized raw-human file;
- applies no filter graph, gain, time stretch, pitch shift or artistic DSP;
- preserves the original frozen source SHA-256 as the one-shot input authority.

The Windows portable runtime workflow is also retriggered whenever this conversion implementation changes.