### PR TITLE
fix: enforce explicit spoken language for multilingual Edge voices

### DIFF
--- a/src/audio_engine/providers/edge.py
+++ b/src/audio_engine/providers/edge.py
@@ -10,15 +10,27 @@ def _locale_from_voice(voice):
     return match.group(1) if match else None
 
 
-def _speech_locale(communicate):
-    """Resolve the SSML language independently from the provider voice identity.
+def _speech_locale(config):
+    """Resolve the root SSML locale from explicit transport or voice identity."""
+    explicit = getattr(config, "_audio_engine_language_locale", None)
+    return explicit or _locale_from_voice(getattr(config, "voice", None))
 
-    Normal voices keep their provider locale. Multilingual laboratory calls may
-    attach `_audio_engine_language_locale` to request French while deliberately
-    retaining a voice whose native provider locale is different.
+
+def _is_multilingual_voice(voice):
+    return "Multilingual" in str(voice or "")
+
+
+def _explicit_language_scoped_text(config, escaped_text):
+    """Force spoken language only for multilingual voices with explicit locale.
+
+    Azure multilingual voices use the SSML <lang xml:lang> element to select
+    the spoken language/accent. Native voices intentionally keep the existing
+    root-locale-only path.
     """
-    explicit = getattr(communicate, "_audio_engine_language_locale", None)
-    return explicit or _locale_from_voice(getattr(communicate, "voice", None))
+    explicit = getattr(config, "_audio_engine_language_locale", None)
+    if not explicit or not _is_multilingual_voice(getattr(config, "voice", None)):
+        return escaped_text
+    return f"<lang xml:lang='{explicit}'>{escaped_text}</lang>"
 
 
 def patch_ssml_locale():
@@ -29,9 +41,12 @@ def patch_ssml_locale():
         import edge_tts.communicate as edge_communicate
         original = getattr(edge_communicate, "mkssml", None)
         if original:
-            def localized(communicate, escaped_text):
-                ssml = original(communicate, escaped_text)
-                locale = _speech_locale(communicate)
+            def localized(config, escaped_text):
+                ssml = original(
+                    config,
+                    _explicit_language_scoped_text(config, escaped_text),
+                )
+                locale = _speech_locale(config)
                 if locale:
                     ssml = re.sub(
                         r"xml:lang=(['\"])en-US\1",
@@ -101,6 +116,9 @@ class EdgeProvider:
                 language_locale = segment.get("language_locale")
                 if language_locale:
                     communicator._audio_engine_language_locale = language_locale
+                    tts_config = getattr(communicator, "tts_config", None)
+                    if tts_config is not None:
+                        tts_config._audio_engine_language_locale = language_locale
                 await communicator.save(str(path))
                 return
             except Exception as exc:

--- a/src/audio_engine/voice/render.py
+++ b/src/audio_engine/voice/render.py
@@ -43,6 +43,7 @@ def voice_content_key(segment, provider_name):
         "volume": segment.get("volume", "+0%"),
         "provider_parameters": segment.get("provider_parameters"),
         "provider_seed": segment.get("provider_seed"),
+        "language_locale": segment.get("language_locale"),
     }
     if segment.get("performance_provider"):
         payload["casting_identity"] = segment.get("casting_identity")
@@ -71,6 +72,7 @@ def _voice_fingerprint_for_cache_identity(segment, provider_name, cache_identity
         "volume": segment.get("volume", "+0%"),
         "provider_parameters": segment.get("provider_parameters"),
         "provider_seed": segment.get("provider_seed"),
+        "language_locale": segment.get("language_locale"),
     }
     if segment.get("performance_provider"):
         payload["casting_identity"] = segment.get("casting_identity")
@@ -166,6 +168,7 @@ def _timing_metadata(segment, provider, fingerprint, path):
         "rate": segment.get("rate", "+0%"),
         "pitch": segment.get("pitch", "+0Hz"),
         "volume": segment.get("volume", "+0%"),
+        "language_locale": segment.get("language_locale"),
         "text_chars": len(text),
         "text_words": len(text.split()),
         "edge_silence_normalized": _edge_silence_normalization_enabled(provider),

--- a/tests/test_edge_locale.py
+++ b/tests/test_edge_locale.py
@@ -5,8 +5,16 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from audio_engine.providers.edge import EdgeProvider, _speech_locale
-from audio_engine.voice.render import provider_cache_identity
+from audio_engine.providers.edge import (
+    EdgeProvider,
+    _explicit_language_scoped_text,
+    _speech_locale,
+)
+from audio_engine.voice.render import (
+    provider_cache_identity,
+    voice_content_key,
+    voice_fingerprint,
+)
 
 
 class EdgeLocaleTests(unittest.TestCase):
@@ -34,6 +42,43 @@ class EdgeLocaleTests(unittest.TestCase):
             _audio_engine_language_locale="fr-FR",
         )
         self.assertEqual(_speech_locale(communicate), "fr-FR")
+
+    def test_explicit_locale_wraps_only_multilingual_voice_with_lang_element(self):
+        multi = SimpleNamespace(
+            voice="fr-FR-RemyMultilingualNeural",
+            _audio_engine_language_locale="fr-FR",
+        )
+        native = SimpleNamespace(
+            voice="fr-FR-HenriNeural",
+            _audio_engine_language_locale="fr-FR",
+        )
+        self.assertEqual(
+            _explicit_language_scoped_text(multi, "Bonjour."),
+            "<lang xml:lang='fr-FR'>Bonjour.</lang>",
+        )
+        self.assertEqual(
+            _explicit_language_scoped_text(native, "Bonjour."),
+            "Bonjour.",
+        )
+
+    def test_explicit_locale_participates_in_voice_cache_identity(self):
+        provider = EdgeProvider()
+        baseline = {
+            "text": "Qui es-tu ?",
+            "voice": "fr-FR-RemyMultilingualNeural",
+            "rate": "+5%",
+            "pitch": "+8Hz",
+            "volume": "+2%",
+        }
+        localized = {**baseline, "language_locale": "fr-FR"}
+        self.assertNotEqual(
+            voice_content_key(baseline, "edge"),
+            voice_content_key(localized, "edge"),
+        )
+        self.assertNotEqual(
+            voice_fingerprint(baseline, provider),
+            voice_fingerprint(localized, provider),
+        )
 
     def test_unavailable_voice_is_reported_explicitly_after_provider_retries(self):
         class FakeNoAudioReceived(Exception):
@@ -83,6 +128,7 @@ class EdgeLocaleTests(unittest.TestCase):
             def __init__(self, text, voice, rate, pitch, volume):
                 self.text = text
                 self.voice = voice
+                self.tts_config = SimpleNamespace(voice=voice)
                 captured["instance"] = self
 
             async def save(self, path):
@@ -103,6 +149,10 @@ class EdgeLocaleTests(unittest.TestCase):
             self.assertTrue(output.exists())
             self.assertEqual(
                 captured["instance"]._audio_engine_language_locale,
+                "fr-FR",
+            )
+            self.assertEqual(
+                captured["instance"].tts_config._audio_engine_language_locale,
                 "fr-FR",
             )
 


### PR DESCRIPTION
Technical repair for recit-audioguide #112 P7 Round 2 Télémaque context only.

Scope:
- when an Edge segment explicitly carries `language_locale` and its voice is multilingual, wrap the already-escaped text in SSML `<lang xml:lang='...'>`;
- attach the explicit locale to the actual edge-tts TTSConfig used by `mkssml`;
- include `language_locale` in voice content/fingerprint metadata so localized clips cannot reuse pre-locale cache entries;
- native voices such as `fr-FR-HenriNeural` keep the existing root-locale-only path.

No voice change, no rate/pitch/volume change, no text change, no provider change, no artistic tuning.