### PR TITLE
fix: keep explicit Edge locale inside supported SSML shape

### DIFF
--- a/src/audio_engine/providers/edge.py
+++ b/src/audio_engine/providers/edge.py
@@ -16,23 +16,6 @@ def _speech_locale(config):
     return explicit or _locale_from_voice(getattr(config, "voice", None))
 
 
-def _is_multilingual_voice(voice):
-    return "Multilingual" in str(voice or "")
-
-
-def _explicit_language_scoped_text(config, escaped_text):
-    """Force spoken language only for multilingual voices with explicit locale.
-
-    Azure multilingual voices use the SSML <lang xml:lang> element to select
-    the spoken language/accent. Native voices intentionally keep the existing
-    root-locale-only path.
-    """
-    explicit = getattr(config, "_audio_engine_language_locale", None)
-    if not explicit or not _is_multilingual_voice(getattr(config, "voice", None)):
-        return escaped_text
-    return f"<lang xml:lang='{explicit}'>{escaped_text}</lang>"
-
-
 def patch_ssml_locale():
     global _PATCHED
     if _PATCHED:
@@ -42,10 +25,7 @@ def patch_ssml_locale():
         original = getattr(edge_communicate, "mkssml", None)
         if original:
             def localized(config, escaped_text):
-                ssml = original(
-                    config,
-                    _explicit_language_scoped_text(config, escaped_text),
-                )
+                ssml = original(config, escaped_text)
                 locale = _speech_locale(config)
                 if locale:
                     ssml = re.sub(

--- a/tests/test_edge_locale.py
+++ b/tests/test_edge_locale.py
@@ -5,11 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from audio_engine.providers.edge import (
-    EdgeProvider,
-    _explicit_language_scoped_text,
-    _speech_locale,
-)
+from audio_engine.providers.edge import EdgeProvider, _speech_locale
 from audio_engine.voice.render import (
     provider_cache_identity,
     voice_content_key,
@@ -43,25 +39,8 @@ class EdgeLocaleTests(unittest.TestCase):
         )
         self.assertEqual(_speech_locale(communicate), "fr-FR")
 
-    def test_explicit_locale_wraps_only_multilingual_voice_with_lang_element(self):
-        multi = SimpleNamespace(
-            voice="fr-FR-RemyMultilingualNeural",
-            _audio_engine_language_locale="fr-FR",
-        )
-        native = SimpleNamespace(
-            voice="fr-FR-HenriNeural",
-            _audio_engine_language_locale="fr-FR",
-        )
-        self.assertEqual(
-            _explicit_language_scoped_text(multi, "Bonjour."),
-            "<lang xml:lang='fr-FR'>Bonjour.</lang>",
-        )
-        self.assertEqual(
-            _explicit_language_scoped_text(native, "Bonjour."),
-            "Bonjour.",
-        )
-
     def test_explicit_locale_participates_in_voice_cache_identity(self):
+
         provider = EdgeProvider()
         baseline = {
             "text": "Qui es-tu ?",


### PR DESCRIPTION
Follow-up to #270 after real father-context run `33745901459`.

The Edge consumer endpoint used by `edge-tts 7.2.8` rejects custom SSML beyond its generated single voice/prosody shape. The added `<lang>` caused `NoAudioReceived`.

This narrow hotfix:
- removes only the unsupported custom `<lang>` wrapper;
- keeps explicit `language_locale` propagated to the actual TTSConfig/root SSML locale;
- keeps `language_locale` in voice content/fingerprint/timing metadata so locale-aware clips cannot reuse pre-locale cache entries;
- changes no voice, rate, pitch, volume, provider, or normalization behavior.