### PR TITLE
fix: restore BeltOut portable runtime revision proof

### DIFF
--- a/src/audio_engine/voice_conversion.py
+++ b/src/audio_engine/voice_conversion.py
@@ -65,11 +65,12 @@ def load_beltout_checkpoint_manifest(path):
     return data
 
 
-def _verify_git_revision(source_root: Path, expected_revision: str):
+def _verify_beltout_revision(source_root: Path, expected_revision: str):
     if not _GIT_SHA_RE.fullmatch(str(expected_revision or "")):
         raise ContractError("BeltOut expected revision must be an exact 40-char Git SHA")
     if not source_root.is_dir():
         raise ContractError(f"BeltOut source directory not found: {source_root}")
+
     try:
         probe = subprocess.run(
             ["git", "-C", str(source_root), "rev-parse", "HEAD"],
@@ -78,14 +79,67 @@ def _verify_git_revision(source_root: Path, expected_revision: str):
             stderr=subprocess.PIPE,
             check=False,
         )
-    except OSError as exc:
-        raise ContractError(f"Unable to inspect BeltOut Git revision: {exc}") from exc
-    actual = (probe.stdout or "").strip()
-    if probe.returncode != 0 or actual != expected_revision:
+    except OSError:
+        probe = None
+
+    if probe is not None and probe.returncode == 0:
+        actual = (probe.stdout or "").strip()
+        if actual != expected_revision:
+            raise ContractError(
+                f"BeltOut source revision mismatch: {actual or 'unavailable'} != {expected_revision}"
+            )
+        return {
+            "revision": actual,
+            "proof": "git-head",
+            "manifest_path": None,
+            "manifest_sha256": None,
+        }
+
+    manifest_path = source_root.parent / "runtime-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContractError(
+            "BeltOut source revision unavailable from Git and portable runtime "
+            f"manifest is invalid: {exc}"
+        ) from exc
+
+    if not isinstance(manifest, dict):
+        raise ContractError("BeltOut portable runtime manifest must be an object")
+    if manifest.get("schema") != "beltout-portable-runtime-v1":
+        raise ContractError("BeltOut portable runtime manifest schema mismatch")
+    actual = manifest.get("beltout_revision")
+    if actual != expected_revision:
         raise ContractError(
             f"BeltOut source revision mismatch: {actual or 'unavailable'} != {expected_revision}"
         )
-    return actual
+    if manifest.get("contains_human_audio") is not False:
+        raise ContractError(
+            "BeltOut portable runtime manifest must explicitly exclude human audio"
+        )
+
+    checkpoints = manifest.get("checkpoints")
+    if not isinstance(checkpoints, list) or not checkpoints:
+        raise ContractError(
+            "BeltOut portable runtime manifest must bind checkpoint evidence"
+        )
+    for item in checkpoints:
+        if not isinstance(item, dict):
+            raise ContractError(
+                "BeltOut portable runtime manifest checkpoint evidence is invalid"
+            )
+        digest = item.get("sha256")
+        if not isinstance(digest, str) or not _SHA256_RE.fullmatch(digest):
+            raise ContractError(
+                "BeltOut portable runtime manifest checkpoint SHA-256 is invalid"
+            )
+
+    return {
+        "revision": expected_revision,
+        "proof": "portable-runtime-manifest",
+        "manifest_path": str(manifest_path),
+        "manifest_sha256": _sha256(manifest_path),
+    }
 
 
 def verify_beltout_conversion_inputs(
@@ -141,7 +195,7 @@ def verify_beltout_conversion_inputs(
             f"BeltOut target reference SHA-256 mismatch: {actual_target_sha} != {target_reference_sha256}"
         )
 
-    revision = _verify_git_revision(beltout_source, expected_revision)
+    revision_proof = _verify_beltout_revision(beltout_source, expected_revision)
     manifest = load_beltout_checkpoint_manifest(checkpoint_manifest)
     verified_checkpoints = {}
     for role in _REQUIRED_CHECKPOINT_ROLES:
@@ -173,7 +227,8 @@ def verify_beltout_conversion_inputs(
         "target_reference": target_reference,
         "target_reference_sha256": actual_target_sha,
         "beltout_source": beltout_source,
-        "expected_revision": revision,
+        "expected_revision": revision_proof["revision"],
+        "revision_proof": revision_proof,
         "checkpoint_dir": checkpoint_dir,
         "checkpoints": verified_checkpoints,
         "output": output,
@@ -462,6 +517,7 @@ def convert_beltout_once(
             "source_sha256": validated["source_sha256"],
             "target_reference_sha256": validated["target_reference_sha256"],
             "beltout_revision": validated["expected_revision"],
+            "beltout_revision_proof": validated.get("revision_proof"),
             "checkpoints": {
                 role: {
                     "file": item["file"],

--- a/tests/test_voice_conversion.py
+++ b/tests/test_voice_conversion.py
@@ -96,6 +96,139 @@ class BeltOutVoiceConversionTests(unittest.TestCase):
                     n_timesteps=10,
                 )
 
+    def _portable_revision_fixture(self, root, revision="a" * 40):
+        root = Path(root)
+        source = root / "source.wav"
+        target = root / "target.wav"
+        source.write_bytes(b"source")
+        target.write_bytes(b"target")
+
+        checkpoint_dir = root / "checkpoints"
+        checkpoint_dir.mkdir()
+        for role in ROLES:
+            (checkpoint_dir / f"{role}.bin").write_bytes(role.encode())
+
+        portable = root / "portable"
+        beltout_source = portable / "beltout-src"
+        beltout_source.mkdir(parents=True)
+        runtime_manifest = {
+            "schema": "beltout-portable-runtime-v1",
+            "beltout_revision": revision,
+            "python": "3.12",
+            "torch": "2.6.0+cpu",
+            "torchaudio": "2.6.0+cpu",
+            "checkpoints": [
+                {
+                    "file": f"{role}.bin",
+                    "sha256": sha_bytes(role.encode()),
+                    "bytes": len(role.encode()),
+                }
+                for role in ROLES
+            ],
+            "contains_human_audio": False,
+        }
+        (portable / "runtime-manifest.json").write_text(
+            json.dumps(runtime_manifest),
+            encoding="utf-8",
+        )
+        return {
+            "source": source,
+            "target": target,
+            "checkpoint_dir": checkpoint_dir,
+            "checkpoint_manifest": self.checkpoint_manifest(root),
+            "beltout_source": beltout_source,
+        }
+
+    def test_portable_runtime_manifest_restores_revision_proof_without_git(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = self._portable_revision_fixture(tmp)
+            with patch(
+                "audio_engine.voice_conversion.subprocess.run",
+                return_value=SimpleNamespace(returncode=128, stdout="", stderr="not a git repo"),
+            ):
+                result = verify_beltout_conversion_inputs(
+                    source=fixture["source"],
+                    source_sha256=sha_bytes(b"source"),
+                    target_reference=fixture["target"],
+                    target_reference_sha256=sha_bytes(b"target"),
+                    beltout_source=fixture["beltout_source"],
+                    expected_revision="a" * 40,
+                    checkpoint_dir=fixture["checkpoint_dir"],
+                    checkpoint_manifest=fixture["checkpoint_manifest"],
+                    output=Path(tmp) / "out.wav",
+                    report=Path(tmp) / "report.json",
+                    seed=1,
+                    n_timesteps=10,
+                )
+
+            self.assertEqual(result["expected_revision"], "a" * 40)
+            self.assertEqual(
+                result["revision_proof"]["proof"],
+                "portable-runtime-manifest",
+            )
+            self.assertRegex(
+                result["revision_proof"]["manifest_sha256"],
+                r"^[0-9a-f]{64}$",
+            )
+
+    def test_portable_runtime_manifest_rejects_wrong_revision(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = self._portable_revision_fixture(tmp, revision="b" * 40)
+            with (
+                patch(
+                    "audio_engine.voice_conversion.subprocess.run",
+                    return_value=SimpleNamespace(
+                        returncode=128,
+                        stdout="",
+                        stderr="not a git repo",
+                    ),
+                ),
+                self.assertRaisesRegex(ContractError, "source revision mismatch"),
+            ):
+                verify_beltout_conversion_inputs(
+                    source=fixture["source"],
+                    source_sha256=sha_bytes(b"source"),
+                    target_reference=fixture["target"],
+                    target_reference_sha256=sha_bytes(b"target"),
+                    beltout_source=fixture["beltout_source"],
+                    expected_revision="a" * 40,
+                    checkpoint_dir=fixture["checkpoint_dir"],
+                    checkpoint_manifest=fixture["checkpoint_manifest"],
+                    output=Path(tmp) / "out.wav",
+                    report=Path(tmp) / "report.json",
+                    seed=1,
+                    n_timesteps=10,
+                )
+
+    def test_git_revision_mismatch_cannot_fallback_to_portable_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = self._portable_revision_fixture(tmp, revision="a" * 40)
+            with (
+                patch(
+                    "audio_engine.voice_conversion.subprocess.run",
+                    return_value=SimpleNamespace(
+                        returncode=0,
+                        stdout=("b" * 40) + "\n",
+                        stderr="",
+                    ),
+                ),
+                self.assertRaisesRegex(ContractError, "source revision mismatch"),
+            ):
+                verify_beltout_conversion_inputs(
+                    source=fixture["source"],
+                    source_sha256=sha_bytes(b"source"),
+                    target_reference=fixture["target"],
+                    target_reference_sha256=sha_bytes(b"target"),
+                    beltout_source=fixture["beltout_source"],
+                    expected_revision="a" * 40,
+                    checkpoint_dir=fixture["checkpoint_dir"],
+                    checkpoint_manifest=fixture["checkpoint_manifest"],
+                    output=Path(tmp) / "out.wav",
+                    report=Path(tmp) / "report.json",
+                    seed=1,
+                    n_timesteps=10,
+                )
+
     def test_success_report_binds_inputs_conversion_and_output(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
#179 runtime-proof repair only.

This does not create or modify a BeltOut runtime and does not run inference.

It fixes the execution gate that currently rejects the already-qualified portable runtime because its build intentionally removes `.git` after:
- checking out exact BeltOut revision `f71295e33cc9c0092083089ed0f9c1a532e77e6b`;
- verifying `git rev-parse HEAD`;
- writing that revision into `runtime-manifest.json`;
- passing the portable import smoke test.

The verifier now:
- keeps Git HEAD as the primary proof when available;
- never falls back when a present Git HEAD conflicts;
- accepts the existing `beltout-portable-runtime-v1` manifest only when Git metadata is absent;
- requires exact revision match, no-human-audio declaration, and checkpoint hash evidence.

No inference code, seeds, n_timesteps, checkpoint selection, model code, or DSP behavior changes.